### PR TITLE
Always attempt to save to sim directory

### DIFF
--- a/ulc_mm_package/scope_constants.py
+++ b/ulc_mm_package/scope_constants.py
@@ -69,11 +69,14 @@ SIMULATION = MS_SIMULATE_FLAG > 0
 print(f"Simulation mode: {SIMULATION}")
 
 # ================ SSD directory constants ================ #
-if SIMULATION:
+SSD_DIR = "/media/pi/"
+try:
+    EXT_DIR = SSD_DIR + listdir(SSD_DIR)[0] + "/"
+except FileNotFoundError:
     SSD_DIR = "../QtGUI/sim_media/pi/"
-else:
-    SSD_DIR = "/media/pi/"
-EXT_DIR = SSD_DIR + listdir(SSD_DIR)[0] + "/"
+    EXT_DIR = SSD_DIR + listdir(SSD_DIR)[0] + "/"
+
+print(f"External directory: {EXT_DIR}")
 
 # ================ Camera constants ================ #
 AVT_VENDOR_ID = 0x1AB2


### PR DESCRIPTION
This solves the issue originally addressed in PR#121 (ie. prevents `scope_constants.py` from crashing). I have mixed feelings on whether this is a good fix though.

If we merge this: If the SSD is accidentally unplugged in Uganda, it quietly defaults to a local directory -- ie. we will not receive this data when they ship the SSDs

If we don't merge this (PREFERRED): We just need to plug in an SSD whenever we're not in simulation mode. This option is more failsafe.

------------------

Many thanks to contributing to czbiohub/ulc-malaria-scope!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

## PR checklist
 - [ ] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] Ensure the test suite passes with [pytest](https://docs.pytest.org/en/latest/) . (command to run: `pytest` or `make coverage` if you want to see which lines don't have tests yet)
 - [ ] Make sure your code is linted and autoformatted using [black](https://github.com/psf/black) (`black . --check` lists the lines in programs to be reformatted, but please do black . from your repo to actually lint the code).
 - [ ] Documentation in `usage.md` is updated
 - [ ] `README.md` is updated
