### PR TITLE
allow inference of both Autofocus and YOGO

### DIFF
--- a/ulc_mm_package/neural_nets/infer.py
+++ b/ulc_mm_package/neural_nets/infer.py
@@ -229,7 +229,7 @@ if __name__ == "__main__":
 
     results = []
     if args.output is None:
-        for res in infer_func(models, tqdm(image_loader)):
+        for res in infer_func(models, image_loader):
             print(res)
             if args.allan_dev:
                 results.append(res)


### PR DESCRIPTION
basic addition to `infer.py`, a tool I use to look at how the NCS side of things are doing. It has no usage outside of that!