### PR TITLE
avt dropped frame hanging fix

### DIFF
--- a/ulc_mm_package/hardware/real/camera.py
+++ b/ulc_mm_package/hardware/real/camera.py
@@ -90,8 +90,10 @@ class AVTCamera:
         self.vimba.__exit__(*sys.exc_info())
 
     def _frame_handler(self, cam, frame):
-        if self.queue.full():
-            self.queue.get()
+        try:
+            self.queue.get_nowait()
+        except queue.Empty:
+            pass
         if frame.get_status() == vimba.FrameStatus.Complete:
             self.queue.put((np.copy(frame.as_numpy_ndarray()[:, :, 0]), perf_counter()))
         cam.queue_frame(frame)


### PR DESCRIPTION
`_frame_handler()` is a callback that the camera uses. We check if the `queue` is full and remove an image if it is before putting in a new now. 

(I feel like an idiot) - there's an obvious risk here that between the time when we check the queue is full and put in a new image, that `yieldImages()` will call the queue and pull out an image. In this case, the `queue.get()` in `_frame_handler()` will hang indefinitely (since it is a blocking call). 

The easy/obvious solution is to use a `get_nowait()` and catch the exception, and continue. 

Big thanks to Paul for catching this!