### PR TITLE
fix NCS seg fault

### DIFF
--- a/ulc_mm_package/neural_nets/NCSModel.py
+++ b/ulc_mm_package/neural_nets/NCSModel.py
@@ -244,4 +244,4 @@ class NCSModel:
         return [maybe_list]
 
     def _format_image_to_tensor(self, img: npt.NDArray) -> List[Tensor]:
-        return Tensor(np.expand_dims(img, (0, 3)), shared_memory=True)
+        return Tensor(np.expand_dims(img, (0, 3)), shared_memory=False)


### PR DESCRIPTION
`shared_memory=True` gives a seg fault when another program tries to modify a tensor under inference. setting `shared_memory=False` fixes it