### PR TITLE
Catch other form of exception

### DIFF
--- a/ulc_mm_package/scope_constants.py
+++ b/ulc_mm_package/scope_constants.py
@@ -80,6 +80,10 @@ except FileNotFoundError as e:
     raise FileNotFoundError(
         f"Could not find any folders within {SSD_DIR}, check that SSD is plugged in."
     ) from e
+except IndexError as e:
+    raise IndexError(
+        f"Could not find any folders within {SSD_DIR}, check that SSD is plugged in."
+    ) from e
 
 # ================ Camera constants ================ #
 AVT_VENDOR_ID = 0x1AB2


### PR DESCRIPTION
Bandaid fix to catch the other form of this exception. SSD stuff will eventually be moved into `scope.py`
