### PR TITLE
impl software triggering ver 2

### DIFF
--- a/ulc_mm_package/hardware/real/camera.py
+++ b/ulc_mm_package/hardware/real/camera.py
@@ -127,8 +127,14 @@ class AVTCamera:
                 # of this error.
                 self.full_count += 1
                 self.logger.warning(
-                    "queue full, couldn't add to frames. self.full_count={self.full_count}"
+                    f"queue full, couldn't add to frames. self.full_count={self.full_count}"
                 )
+            except numpy.core._exceptions.MemoryError as e:
+                self.logger.error(
+                    "memory error when trying to copy image into numpy array"
+                )
+                raise e
+
         else:
             self.logger.warning(
                 f"camera returned incomplete frame. self.incomplete_count={self.incomplete_count}"


### PR DESCRIPTION
Better version, found in an issue [here](https://github.com/alliedvision/VimbaPython/issues/60)

Basically same as #143, but it only gets a Frame (i.e. image) from the camera stream if we request one. So far during testing, we have had no dropped nor incomplete frames. #143 has very few incomplete frames (basically during transitions e.g. from cell finder to autofocus, or whatever). Open question: how does it's FPS compare to previous methods?

No dropped, torn, mucked up, e.t.c. frames:

![IMG_4817 Large](https://user-images.githubusercontent.com/20530172/205416924-18b393b9-aa98-4477-aa5f-08f72001bdef.png)


FPS on dev run, trying to put it to work - hovers pretty close to 20 FPS.

![IMG_4818 Large](https://user-images.githubusercontent.com/20530172/205416867-f2fe0a45-9737-44c0-ac12-e73f5d129d6f.png)

On dev run, with everything off, maximizing framerate for datasave, we get ~40 FPS.

wrapping [_get_img](https://github.com/czbiohub/ulc-malaria-scope/pull/146/files#diff-4c568da4c000534bbaf709d8d8edab9d6064d84908e4c5e49e461b61f5274252R158-R164) in `perf_counters`, each call takes ~20 ms, plus minus some time. This is probably too slow.
