### PR TITLE
adding a quick way to run ngrok - python3 ngrok_utils.py

### DIFF
--- a/ulc_mm_package/utilities/ngrok_utils.py
+++ b/ulc_mm_package/utilities/ngrok_utils.py
@@ -196,3 +196,7 @@ def set_ngrok_auth_token():
 
     token = _get_ngrok_auth_token()
     _set_ngrok_auth_token(token)
+
+
+if __name__ == "__main__":
+    print(f"{make_tcp_tunnel()}")


### PR DESCRIPTION
A minor convenience testing update - `python3 ngrok_utils.py` will print the tunnel to the screen.