### PR TITLE
concurrent futures for NCS

### DIFF
--- a/ulc_mm_package/neural_nets/NCSModel.py
+++ b/ulc_mm_package/neural_nets/NCSModel.py
@@ -15,7 +15,6 @@ from functools import partial
 from collections import namedtuple
 from typing import (
     Any,
-    Set,
     List,
     Sequence,
     Optional,


### PR DESCRIPTION
Two things need to be done:
- ~~verify that it is faster on scope in oracle~~ **it is**
- ~~verify that the pool of concurrent futures doesn't build too high~~
    - (I don't think it will - NCS efficiency is a U curve, it gets better given more images, as it can more efficiently batch. One image every 33ms is not the most efficient for it.)
    - regardless we should track and log this metric - something like `logging.debug(f"{len(executor.futures)} NCS futures in {self}")` would do the trick, maybe once every n seconds or n frames 
    - **It does not climb up! I tested "non-completed" futures, and it was always 0. We probably weren't flooding the NCS w/ images fast enough to really fill up the ThreadPoolExecutor pool**

Here is timing `count_parasitemia` in main (sorry for no units, i was throwing this together quick! All units are `seconds`):

![yogo_master](https://user-images.githubusercontent.com/20530172/206036539-41826554-a3ba-47e7-830c-3c241c474487.png)

and here is the same in this branch:

![yogo_concurrent_futures](https://user-images.githubusercontent.com/20530172/206036768-ada3feab-10ca-42ba-bef6-fb68bbacdf88.png)

Notice the mean time is ~roughly the same, but there are no peaks of duration (up to 12 ms!)

~~alternative to #154~~