### PR TITLE
Return existing ngrok

### DIFF
--- a/ulc_mm_package/utilities/ngrok_utils.py
+++ b/ulc_mm_package/utilities/ngrok_utils.py
@@ -150,23 +150,23 @@ def make_tcp_tunnel() -> str:
         Unable to create the ngrok tunnel.
     """
 
-    # First check for existing ngrok tunnel
     try:
+        # Check for existing ngrok tunnel
         if is_ngrok_running():
             addr = get_addr()
             return addr
+        else:
+            # Create a new tunnel
+            try:
+                _kill_old_ngrok_sessions()
+                set_ngrok_auth_token()
+                return _get_public_url_from_ngrok_tunnel_obj(_make_tcp_tunnel())
+            except NgrokError:
+                raise
     except:
         raise NgrokError(
             "NgrokError : existing ngrok tunnel detected but errored out during either is_ngrok_running() or get_addr()."
         )
-
-    # Create a new tunnel
-    try:
-        _kill_old_ngrok_sessions()
-        set_ngrok_auth_token()
-        return _get_public_url_from_ngrok_tunnel_obj(_make_tcp_tunnel())
-    except NgrokError:
-        raise
 
 
 def _get_ngrok_auth_token() -> str:


### PR DESCRIPTION
Returns the address of the already running tunnel.

If we're `ssh'd` in and want to run `oracle.py` or `dev_run.py` - we don't want to get accidentally kicked off when those applications kill old tunnels and create new ones. This change just returns the existing tunnel.