### PR TITLE
remove lid closed handler - don't turn on LED once the lid is closed …

### DIFF
--- a/ulc_mm_package/QtGUI/dev_run.py
+++ b/ulc_mm_package/QtGUI/dev_run.py
@@ -436,9 +436,7 @@ class MalariaScopeGUI(QtWidgets.QMainWindow):
         mscope = MalariaScope()
         self.mscope = mscope
         self.mscope.set_gpio_callback(self.lid_open_handler)
-        # self.mscope.set_gpio_callback(
-        #     self.lid_closed_handler, edge=GPIOEdge.FALLING_EDGE
-        # )
+
         hardware_status = mscope.getComponentStatus()
         self.fan = mscope.fan
 


### PR DESCRIPTION
…unless the user explicitly presses the turn on button