### PR TITLE
Enocder fix

### DIFF
--- a/ulc_mm_package/hardware/scope.py
+++ b/ulc_mm_package/hardware/scope.py
@@ -8,7 +8,7 @@ Components
     - Pneumatic module (pressure sensor + servo)
     - LED (TPS54201DDCT driver)
     - Cooling fans
-    - Rotary encoder
+    - Rotary encoder (disabled for now)
     - Real time clock (PCF8523)
     - Temperature/humidity sensor (SHT31-D)
 """
@@ -54,7 +54,6 @@ class MalariaScope:
         self.pneumatic_module_enabled = False
         self.led_enabled = False
         self.fan_enabled = False
-        self.encoder_enabled = False
         self.ht_sensor_enabled = False
         self.data_storage_enabled = False
         self.tpu_enabled = False
@@ -95,7 +94,6 @@ class MalariaScope:
             Components.PNEUMATIC_MODULE: self.pneumatic_module_enabled,
             Components.LED: self.led_enabled,
             Components.FAN: self.fan_enabled,
-            Components.ENCODER: self.encoder_enabled,
             Components.HT_SENSOR: self.ht_sensor_enabled,
             Components.DATA_STORAGE: self.data_storage_enabled,
             Components.TPU: self.tpu_enabled,


### PR DESCRIPTION
Fixed encoder knob.

Encoder is disabled for now, as we don't actually use it. 