### PR TITLE
Moved SIMULATION import

### DIFF
--- a/ulc_mm_package/QtGUI/oracle.py
+++ b/ulc_mm_package/QtGUI/oracle.py
@@ -33,8 +33,9 @@ from ulc_mm_package.scope_constants import (
     CAMERA_SELECTION,
     SSD_DIR,
     VERBOSE,
+    SIMULATION,
 )
-from ulc_mm_package.hardware.hardware_constants import SIMULATION, DATETIME_FORMAT
+from ulc_mm_package.hardware.hardware_constants import DATETIME_FORMAT
 from ulc_mm_package.image_processing.data_storage import DataStorage
 from ulc_mm_package.image_processing.processing_constants import (
     TOP_PERC_TARGET_VAL,

--- a/ulc_mm_package/QtGUI/scope_op.py
+++ b/ulc_mm_package/QtGUI/scope_op.py
@@ -17,9 +17,9 @@ from PyQt5.QtCore import QObject, pyqtSignal, pyqtSlot
 from ulc_mm_package.hardware.scope import MalariaScope
 from ulc_mm_package.hardware.scope_routines import *
 
-from ulc_mm_package.scope_constants import PER_IMAGE_METADATA_KEYS
+from ulc_mm_package.scope_constants import PER_IMAGE_METADATA_KEYS, SIMULATION
 from ulc_mm_package.hardware.hardware_modules import PressureSensorStaleValue
-from ulc_mm_package.hardware.hardware_constants import SIMULATION, DATETIME_FORMAT
+from ulc_mm_package.hardware.hardware_constants import DATETIME_FORMAT
 from ulc_mm_package.neural_nets.NCSModel import AsyncInferenceResult
 from ulc_mm_package.neural_nets.YOGOInference import YOGO, ClassCountResult
 from ulc_mm_package.neural_nets.neural_network_constants import AF_BATCH_SIZE


### PR DESCRIPTION
One of the constants moved in PR199 had old refs by oracle/scopeop