### PR TITLE
Always ask user to add more sample at the halfway point.

### DIFF
--- a/ulc_mm_package/QtGUI/oracle.py
+++ b/ulc_mm_package/QtGUI/oracle.py
@@ -468,7 +468,7 @@ class Oracle(Machine):
         self.display_message(
             QMessageBox.Icon.Information,
             "Starting run",
-            'Insert flow cell and replace CAP module now. Make sure to close the lid after.\n\nClick "OK" once it is closed',
+            'Insert flow cell and replace CAP module now. Make sure to close the lid after.\n\nClick "OK" once it is closed.',
             buttons=Buttons.OK,
             image=_IMAGE_INSERT_PATH,
         )

--- a/ulc_mm_package/QtGUI/scope_op.py
+++ b/ulc_mm_package/QtGUI/scope_op.py
@@ -402,7 +402,6 @@ class ScopeOp(QObject, Machine):
         self.img_signal.disconnect(self.run_cellfinder)
 
         try:
-            raise NoCellsFound("UHOH")
             self.cellfinder_routine.send(img)
         except StopIteration as e:
             self.cellfinder_result = e.value
@@ -525,12 +524,12 @@ class ScopeOp(QObject, Machine):
         if self.count >= MAX_FRAMES:
             self.to_intermission()
         # NOTE : Mid experiment pause is intended to compensate for commenting out YOGO/density check
-        if self.count >= MAX_FRAMES / 2:
+        if self.count > MAX_FRAMES / 2:
             self.send_pause.emit(
                 "Experiment halfway point reached",
                 (
                     "Midway through the experiment, cell density tends to decrease. "
-                    "Pausing operation so that more sample can be added without ending the experiment."
+                    "Pausing operation so that more sample can be added for this experiment."
                     '\n\nClick "OK" and wait for the next dialog before removing the CAP module.'
                 ),
             )


### PR DESCRIPTION
In case we need to comment out YOGO to prevent memory buildup, we will no longer have a cell density check. This branch prompts the user to add more sample at the halfway point to compensate for the unknown cell density.