### PR TITLE
reinit flowcontrol in sim mode when error occurs

### DIFF
--- a/ulc_mm_package/QtGUI/scope_op.py
+++ b/ulc_mm_package/QtGUI/scope_op.py
@@ -612,6 +612,12 @@ class ScopeOp(QObject, Machine):
                         f"Ignoring flowcontrol exception in simulation mode - {e}"
                     )
                     flowrate = None
+
+                    self.flowcontrol_routine = flowControlRoutine(
+                        self.mscope, self.target_flowrate, None
+                    )
+                    self.flowcontrol_routine.send(None)
+
             t1 = perf_counter()
             self._update_metadata_if_verbose("flowrate_dt", t1 - t0)
 


### PR DESCRIPTION
Why was this error not ocurring before? We recently switched to default flowrate of `medium`, could that have something to do w/ it? @mwlkhoo 