### PR TITLE
Made all timers precise

### DIFF
--- a/ulc_mm_package/QtGUI/acquisition.py
+++ b/ulc_mm_package/QtGUI/acquisition.py
@@ -9,7 +9,13 @@ import traceback
 import numpy as np
 
 from time import perf_counter, sleep
-from PyQt5.QtCore import QObject, QTimer, pyqtSignal, pyqtSlot
+from PyQt5.QtCore import (
+    QObject,
+    QTimer,
+    pyqtSignal,
+    pyqtSlot,
+    Qt,
+)
 
 from ulc_mm_package.hardware.scope import MalariaScope
 from ulc_mm_package.QtGUI.gui_constants import ACQUISITION_PERIOD
@@ -34,9 +40,11 @@ class Acquisition(QObject):
     @pyqtSlot()
     def create_timers(self):
         self.acquisition_timer = QTimer()
+        self.acquisition_timer.setTimerType(Qt.PreciseTimer)
         self.acquisition_timer.timeout.connect(self.get_img)
 
         self.liveview_timer = QTimer()
+        self.liveview_timer.setTimerType(Qt.PreciseTimer)
         self.liveview_timer.timeout.connect(self.send_img)
 
         self.logger.info("Created acquisition and liveview timers.")


### PR DESCRIPTION
Change all QTimers to precise timers. This will prevent the experiment runtime tracker from skipping seconds. See difference in performance below:
```
COARSE TIMER
requested: 1 ms, measured: median(min/max) 1.0 (0.28/1.72) ms
requested: 2 ms, measured: median(min/max) 2.0 (0.98/2.74) ms
requested: 3 ms, measured: median(min/max) 3.0 (0.48/5.45) ms
requested: 4 ms, measured: median(min/max) 4.0 (2.98/5.31) ms
requested: 5 ms, measured: median(min/max) 5.0 (4.00/5.82) ms
requested: 6 ms, measured: median(min/max) 6.0 (5.18/6.96) ms
requested: 7 ms, measured: median(min/max) 7.0 (5.96/8.01) ms
requested: 8 ms, measured: median(min/max) 8.0 (7.08/8.70) ms
requested: 9 ms, measured: median(min/max) 9.0 (6.10/11.97) ms
requested: 10 ms, measured: median(min/max) 10.0 (5.41/23.30) ms
requested: 12 ms, measured: median(min/max) 12.0 (9.42/14.56) ms
requested: 14 ms, measured: median(min/max) 14.0 (11.30/16.21) ms
requested: 16 ms, measured: median(min/max) 16.0 (14.24/18.26) ms
requested: 18 ms, measured: median(min/max) 17.1 (13.88/37.40) ms
requested: 20 ms, measured: median(min/max) 32.2 (15.78/45.03) ms
requested: 22 ms, measured: median(min/max) 32.2 (16.39/39.70) ms
requested: 24 ms, measured: median(min/max) 31.5 (16.54/40.31) ms
requested: 26 ms, measured: median(min/max) 32.0 (17.28/43.90) ms
requested: 28 ms, measured: median(min/max) 31.7 (14.81/42.46) ms
requested: 30 ms, measured: median(min/max) 32.2 (16.37/42.98) ms
requested: 32 ms, measured: median(min/max) 46.8 (17.40/57.72) ms
requested: 34 ms, measured: median(min/max) 47.6 (32.03/60.76) ms
requested: 36 ms, measured: median(min/max) 48.0 (32.41/59.31) ms
requested: 38 ms, measured: median(min/max) 48.3 (31.70/58.25) ms
requested: 40 ms, measured: median(min/max) 48.7 (31.80/59.27) ms
requested: 42 ms, measured: median(min/max) 47.8 (32.49/62.34) ms

PRECISE TIMER
requested: 1 ms, measured: median(min/max) 1.0 (0.26/4.85) ms
requested: 2 ms, measured: median(min/max) 2.0 (0.75/4.56) ms
requested: 3 ms, measured: median(min/max) 3.0 (1.11/4.99) ms
requested: 4 ms, measured: median(min/max) 4.0 (2.52/5.52) ms
requested: 5 ms, measured: median(min/max) 5.0 (3.12/7.47) ms
requested: 6 ms, measured: median(min/max) 6.0 (3.30/8.51) ms
requested: 7 ms, measured: median(min/max) 7.0 (6.01/8.46) ms
requested: 8 ms, measured: median(min/max) 8.0 (7.21/8.95) ms
requested: 9 ms, measured: median(min/max) 9.1 (6.65/11.25) ms
requested: 10 ms, measured: median(min/max) 10.0 (8.62/10.98) ms
requested: 12 ms, measured: median(min/max) 12.0 (9.84/14.58) ms
requested: 14 ms, measured: median(min/max) 13.9 (11.90/16.13) ms
requested: 16 ms, measured: median(min/max) 16.0 (14.78/17.21) ms
requested: 18 ms, measured: median(min/max) 18.0 (15.74/20.31) ms
requested: 20 ms, measured: median(min/max) 20.0 (17.29/22.55) ms
requested: 22 ms, measured: median(min/max) 22.0 (20.15/23.80) ms
requested: 24 ms, measured: median(min/max) 24.0 (19.12/28.28) ms
requested: 26 ms, measured: median(min/max) 26.0 (23.78/28.39) ms
requested: 28 ms, measured: median(min/max) 28.0 (25.36/30.80) ms
requested: 30 ms, measured: median(min/max) 30.0 (28.23/31.89) ms
requested: 32 ms, measured: median(min/max) 32.0 (30.24/34.07) ms
requested: 34 ms, measured: median(min/max) 34.0 (31.90/35.97) ms
requested: 36 ms, measured: median(min/max) 36.0 (34.35/37.61) ms
requested: 38 ms, measured: median(min/max) 38.0 (35.76/40.27) ms
requested: 40 ms, measured: median(min/max) 40.0 (38.38/41.50) ms
requested: 42 ms, measured: median(min/max) 42.0 (39.77/43.83) ms
```