### PR TITLE
Reset liveview update period after unpausing

### DIFF
--- a/ulc_mm_package/QtGUI/scope_op.py
+++ b/ulc_mm_package/QtGUI/scope_op.py
@@ -282,6 +282,7 @@ class ScopeOp(QObject, NamedMachine):
         self.mscope.led.turnOff()
 
     def _end_pause(self, *args):
+        self.set_period.emit(ACQUISITION_PERIOD)
         self.mscope.led.turnOn()
         self.start_time = perf_counter()
         self.running = True


### PR DESCRIPTION
Make sure liveview updates at high FPS during setup states after unpause.