### PR TITLE
Add leading zeros to subsample

### DIFF
--- a/ulc_mm_package/image_processing/data_storage.py
+++ b/ulc_mm_package/image_processing/data_storage.py
@@ -15,6 +15,7 @@ from ulc_mm_package.image_processing.processing_constants import (
     MIN_GB_REQUIRED,
     NUM_SUBSEQUENCES,
     SUBSEQUENCE_LENGTH,
+    MAX_FRAMES,
 )
 
 
@@ -36,6 +37,9 @@ class DataStorage:
         else:
             self.dt = 0
         self.prev_write_time = 0
+
+        # Calculate max number of digits, to zeropad subsample img filenames
+        self.digits = int(np.log10(MAX_FRAMES - 1)) + 1
 
     def createTopLevelFolder(self, external_dir: str, datetime_str: str):
         # Create top-level directory for this program run.
@@ -235,7 +239,7 @@ class DataStorage:
 
         for idx in indices:
             img = self.zw.array[..., idx]
-            filepath = path.join(sub_seq_path, f"{idx}.png")
+            filepath = path.join(sub_seq_path, f"{idx:0{self.digits}d}.png")
             cv2.imwrite(filepath, img)
 
     def _create_subseq_folder(self) -> str:


### PR DESCRIPTION
Add leading zeros to image subsample filenames, so that file sorting by name works correctly