### PR TITLE
update min cell count threshold

### DIFF
--- a/ulc_mm_package/image_processing/processing_constants.py
+++ b/ulc_mm_package/image_processing/processing_constants.py
@@ -45,6 +45,6 @@ RBC_THUMBNAIL_PATH = (
 CELLS_FOUND_THRESHOLD = 9000  # It's got to be... OVER 9000!!!!!!
 CROSS_CORR_CELL_DENSITY_THRESHOLD = 6500
 
-MIN_CELL_COUNT = 10
+MIN_CELL_COUNT = 20
 CELL_DENSITY_CHECK_PERIOD_S = 0.5  # How often to check cell density
 CELL_DENSITY_HISTORY_LEN = 50  # Number of continuuous cell density measurements that need to be < MIN_CELL_COUNT before an exception is raised


### PR DESCRIPTION
Did a run on `oracle` and ran until I started seeing noticeable density drop (had to let it run until timeout of 10mins, then run again).

Here's the graph of cell counts. We can see that it doesn't dip below ~20 cells. With our current threshold of `MIN_CELL_COUNT=10`, it's exceedingly unlikely that the low density exception will be raised. (As to whether something funky is going on with YOGO at low cell densities, I'm unsure).
![rbc_counts](https://user-images.githubusercontent.com/25993326/213315333-fe85a342-f0ad-4a7d-9032-1bc66c8d00a0.png)

