### PR TITLE
Exp timer hotfix

### DIFF
--- a/ulc_mm_package/QtGUI/scope_op.py
+++ b/ulc_mm_package/QtGUI/scope_op.py
@@ -192,7 +192,7 @@ class ScopeOp(QObject, NamedMachine):
         self.cell_counts = np.zeros(len(YOGO_CLASS_LIST), dtype=int)
 
         self.TH_time = None
-        self.start_time = 0
+        self.start_time = None
         self.accumulated_time = 0
 
         self.update_img_count.emit(0)
@@ -322,9 +322,6 @@ class ScopeOp(QObject, NamedMachine):
         self.set_period.emit(ACQUISITION_PERIOD)
         self.mscope.led.turnOn()
 
-        if self.start_time != None:
-            self.start_time = perf_counter()
-            
         self.running = True
 
     def _start_autobrightness_precells(self, *args):


### PR DESCRIPTION
Prevent timer from yielding weird results when paused before `experiment` state starts