### PR TITLE
git detached head hotfix

### DIFF
--- a/ulc_mm_package/QtGUI/oracle.py
+++ b/ulc_mm_package/QtGUI/oracle.py
@@ -537,9 +537,6 @@ class Oracle(Machine):
         except subprocess.CalledProcessError:
             git_branch = "detached head"
 
-
-
-
         self.experiment_metadata["git_branch"] = git_branch
         self.experiment_metadata["git_commit"] = (
             subprocess.check_output(["git", "rev-parse", "HEAD"])


### PR DESCRIPTION
If we are in a detached state, just label branch as `detached head`. Quick example from a sim-mode run in detached head:

```
operator_id,participant_id,flowcell_id,target_flowrate,site,notes,scope,camera,exposure,target_brightness,git_branch,git_commit
,,,"('Medium', 7.58)","Tororo, Uganda",,lfm-ohmu,SIMULATED,0.5,245,detached head,a62d8fe9f3cb4de498a56d2736a3024fc5e888e8
                                                                   ^^^^^^^^^^^^^
```
