### PR TITLE
Git metadata hotfix

### DIFF
--- a/ulc_mm_package/QtGUI/oracle.py
+++ b/ulc_mm_package/QtGUI/oracle.py
@@ -550,7 +550,9 @@ class Oracle(Machine):
                     .strip()
                 )
                 self.experiment_metadata["git_commit"] = (
-                    subprocess.check_output(["git", "rev-list", "--tags", "--max-count=1"])
+                    subprocess.check_output(
+                        ["git", "rev-list", "--tags", "--max-count=1"]
+                    )
                     .decode("ascii")
                     .strip()
                 )


### PR DESCRIPTION
Handle detached head, and get latest commit and tag (instead of branch name)