### PR TITLE
fix numpy ver

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     install_requires=[
         "Pillow",
         "matplotlib==3.4.3",
-        "numpy>=1.21.0",
+        "numpy==1.21.0",
         "opencv-python",
         "PyQt5>=5.15.2",
         "pypylon==1.7.2",


### PR DESCRIPTION
"fix" as in "set", not "fix" as in "correct"

Some versions of numpy don't work w/ openvino