### PR TITLE
Reset steps_from_focus each time to avoid sending stale values

### DIFF
--- a/ulc_mm_package/hardware/scope_routines.py
+++ b/ulc_mm_package/hardware/scope_routines.py
@@ -134,7 +134,7 @@ class Routines:
                 img = yield steps_from_focus
                 steps_from_focus = ssaf_routine.send(img)
 
-                if counter >= nn_constants.AfF_PERIOD_NUM + nn_constants.AF_BATCH_SIZE:
+                if counter >= nn_constants.AF_PERIOD_NUM + nn_constants.AF_BATCH_SIZE:
                     counter = 0
             else:
                 _ = yield None


### PR DESCRIPTION
Yielded `steps_from_focus` in `continuousAutofocusRoutine` sends stale values sometime. This branch should fix this by removing the stale values. 

To be tested on scope. 