### PR TITLE
Metadata compiler fix

### DIFF
--- a/ulc_mm_package/QtGUI/scope_op.py
+++ b/ulc_mm_package/QtGUI/scope_op.py
@@ -592,7 +592,7 @@ class ScopeOp(QObject, NamedMachine):
                     "or restart this run with the same flow cell, or discard this flow cell and use a new one with fresh sample.\n"
                     "Continue running anyway?"
                 ),
-                ERROR_BEHAVIORS.YN.value,
+                ERROR_BEHAVIORS.DEFAULT.YN.value,
             )
         except StopIteration as e:
             self.fastflow_result = e.value


### PR DESCRIPTION
Allow metadata compiler to search a different folder location, and handle unicode exceptions