### PR TITLE
Clip bounding box values to 0 or (max height / max width)

### DIFF
--- a/ulc_mm_package/neural_nets/utils.py
+++ b/ulc_mm_package/neural_nets/utils.py
@@ -93,10 +93,10 @@ def _parse_prediction_tensor(
     pred_half_width = filtered_pred[2] / 2 * img_w
     pred_half_height = filtered_pred[3] / 2 * img_h
 
-    tlx = np.clip(np.rint(xc - pred_half_width).astype(DTYPE), 0)
-    tly = np.clip(np.rint(yc - pred_half_height).astype(DTYPE), 0)
-    brx = np.clip(np.rint(xc + pred_half_width).astype(DTYPE), img_w)
-    bry = np.clip(np.rint(yc + pred_half_height).astype(DTYPE), img_h)
+    tlx = np.clip(np.rint(xc - pred_half_width).astype(DTYPE), 0, img_w)
+    tly = np.clip(np.rint(yc - pred_half_height).astype(DTYPE), 0, img_h)
+    brx = np.clip(np.rint(xc + pred_half_width).astype(DTYPE), 0, img_w)
+    bry = np.clip(np.rint(yc + pred_half_height).astype(DTYPE), 0, img_h)
 
     objectness = filtered_pred[4, :].astype(DTYPE)
     all_confs = filtered_pred[5:, :].astype(DTYPE)


### PR DESCRIPTION
Sometimes we get negative values for bounding boxes at the edge of the screen. 

Not sure of root cause yet, though it seems like conversion to fp16/fp32 is introducing some rounding errors. Typically if there are negative values for the bbox, it's in the -10-0 (for top left) or 0-+10 (for bottom right). 

Need to test on scope (`np.clip` supported as of `numba==0.54.0` so this _ should_ work without a hitch).
