### PR TITLE
Clarify SSAF / motor move wording

### DIFF
--- a/ulc_mm_package/hardware/scope_routines.py
+++ b/ulc_mm_package/hardware/scope_routines.py
@@ -126,7 +126,7 @@ class Routines:
             if throttle_counter >= nn_constants.AF_PERIOD_NUM:
                 img_counter += 1
                 img = yield steps_from_focus, filtered_error, adjusted
-                adjusted = None
+                adjusted = False
 
                 # if mscope.autofocus_model._executor._work_queue.full(), this will block
                 # until an element is removed from the queue


### PR DESCRIPTION
OK, I don't think that we had a negative in there. Though, the variables and interpretation was confusing.

I think we should record *state* of the system. We previously logged `focus_error` and `filtered_focus_error` not as the error as predicted from the model, but the steps that the model had to take:

https://github.com/czbiohub-sf/ulc-malaria-scope/blob/98e7ab7d168399812bf19bddb19b27c3ea5c90ba/ulc_mm_package/QtGUI/scope_op.py#L831-L833

I clarified the language in the autofocus functions: anything that was from the model is `steps_from_focus` or `error`. When feeding a value to `move_rel` it is `steps_to_move`. I only "apply" the negative for `steps_to_move`, so `steps_to_move = -steps_from_focus`, or `steps_to_move = -filtered_error`.

So what is happening here? What you see here is the steps that the system is attempting to move, not the error of the focus system that is reported in the legend.

![image](https://github.com/czbiohub-sf/ulc-malaria-scope/assets/20530172/0400385b-c79e-473a-974f-de9b7d184154)

You can see good corrections around frame 600, 1500. It moves away around 1800 for some reason. After that, the model consistently thinks that it needs to move further away. I think this is a problem with the model.

I think we should merge this PR to clarify the language in `scope_routines`, and test out #427. If that doesn't fix it, I'll have to do more autofocus training!