### PR TITLE
Increase pre-allocated prediction tensor size from 1.5M to 2.5M since…

### DIFF
--- a/ulc_mm_package/neural_nets/predictions_handler.py
+++ b/ulc_mm_package/neural_nets/predictions_handler.py
@@ -21,7 +21,7 @@ from ulc_mm_package.neural_nets.neural_network_constants import (
 NUM_CLASSES = len(YOGO_CLASS_LIST)
 IMG_W, IMG_H = CAMERA_SELECTION.IMG_WIDTH, YOGO_CROP_HEIGHT_PX
 HIGH_CONF_THRESH = 0.7
-MAX_POSSIBLE_PREDICTIONS = 1_500_000
+MAX_POSSIBLE_PREDICTIONS = 2_500_000
 
 
 class PredictionsHandler:


### PR DESCRIPTION
… high hematocrit counts easily exceed 1.5M within 7-8mins

