### PR TITLE
Don't raise exception if re-homing is requested

### DIFF
--- a/ulc_mm_package/hardware/real/motorcontroller.py
+++ b/ulc_mm_package/hardware/real/motorcontroller.py
@@ -195,6 +195,7 @@ class DRV8825Nema:
 
         # Move the motor until it hits the CCW limit switch
         try:
+            self.homed = False
             self.move_rel(dir=Direction.CCW, steps=1e6, timeout_s=homing_timeout)
         except MotorMoveTimeout:
             raise HomingError(


### PR DESCRIPTION
Instead, just allow the user to home again by setting self.homed = False right before, so that it doesn't constrain the move_rel call.