### PR TITLE
LLVM needs to be pip3 installed separately as stated in the OS_setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
         "tqdm==4.63.0",
         "transitions==0.8.11",
         "pyngrok==7.0.3",
-        "llvmlite==0.39.0",
         "numba==0.56.0",
         "Jinja2==3.1.3",
         "xhtml2pdf==0.2.11",


### PR DESCRIPTION
LLVM needs to be pip3 installed separately as stated in the OS_setup.md instructions. Keeping it in `setup.py` causes `pip3 install -e` to fail.