### PR TITLE
Adjust SSAF feedback parameters

### DIFF
--- a/ulc_mm_package/hardware/hardware_constants.py
+++ b/ulc_mm_package/hardware/hardware_constants.py
@@ -6,7 +6,7 @@ RPI_OUTPUT_V = 3.3
 BOARD_STATUS_INDICATOR = 4
 
 # ================ EWMA filter constants ================ #
-FOCUS_EWMA_ALPHA = 0.05
+FOCUS_EWMA_ALPHA = 0.1
 
 # ================ Camera constants ================ #
 DEFAULT_EXPOSURE_MS = 0.5

--- a/ulc_mm_package/neural_nets/neural_network_constants.py
+++ b/ulc_mm_package/neural_nets/neural_network_constants.py
@@ -13,7 +13,7 @@ AF_PERIOD_NUM = int(
 )  # Used for periodic (ie. EWMA) autofocus
 AF_BATCH_SIZE = 10  # Used for single shot autofocus
 
-AF_THRESHOLD = 2
+AF_THRESHOLD = 3
 AF_QSIZE = 10  # For AF_PERIOD_S = 0.5, we have a max delay of 5 sec
 
 AUTOFOCUS_MODEL_DIR = str(


### PR DESCRIPTION
Stared at focus stacks and my hunch is bumping the step threshold to |3| and increasing the response time (bumping up EWMA alpha) may result in better SSAF performance. 

Needs to be tested: initial idea is to do 4 full-runs with the new chips, 2 runs using the original parameters, and 2 using the adjusted ones. Run classic focus metric over those datasets and assess