### PR TITLE
Set a higher confidence threshold for elated-smoke-4492

### DIFF
--- a/ulc_mm_package/neural_nets/neural_network_constants.py
+++ b/ulc_mm_package/neural_nets/neural_network_constants.py
@@ -30,7 +30,9 @@ YOGO_AREA_FILTER_NORMED = YOGO_AREA_FILTER / (
     CAMERA_SELECTION.IMG_HEIGHT * CAMERA_SELECTION.IMG_WIDTH
 )
 YOGO_PRED_THRESHOLD = 0.5
-YOGO_CONF_THRESHOLD = 0.9
+YOGO_CONF_THRESHOLD = (
+    0.99  # TODO: adaptive confidence threshold based on clinical or cultured use case
+)
 YOGO_MODEL_NAME = "elated-smoke-4492"
 YOGO_MODEL_DIR = str(curr_dir / "yogo_model_files" / YOGO_MODEL_NAME / "best.xml")
 


### PR DESCRIPTION
Set a higher confidence threshold, based on the elated-smoke-4492 peformance on the Tororo dataset.

A TODO item is to set the confidence threshold dynamically based on a clinical vs. cultured use case