### PR TITLE
Lower required min pressure difference to be less aggressive

### DIFF
--- a/ulc_mm_package/hardware/hardware_constants.py
+++ b/ulc_mm_package/hardware/hardware_constants.py
@@ -77,7 +77,7 @@ AFC_NUM_IMAGE_PAIRS = 12
 MPRLS_RST = 10
 MPRLS_PWR = 22
 
-MIN_PRESSURE_DIFF = 380  # In units of hPa
+MIN_PRESSURE_DIFF = 360  # In units of hPa
 # ================ Fan constants ================ #
 FAN_GPIO = 5
 CAM_FAN_1 = 23


### PR DESCRIPTION
Context: Atmospheric pressure in Kigali is around ~850 hPa and Perseverance appears to have a smaller syringe range. We snipped some of its excess tubing to reduce dead volume and this helped, however we are now reducing the min pressure set point to have greater margin.