### PR TITLE
Subsample exist_ok fix

### DIFF
--- a/ulc_mm_package/image_processing/data_storage.py
+++ b/ulc_mm_package/image_processing/data_storage.py
@@ -493,7 +493,7 @@ class DataStorage:
             assert self.main_dir is not None, "DataStorage has not been initialized"
             try:
                 dir_path = self.main_dir / self.experiment_folder / "sub_sample_imgs"
-                dir_path.mkdir()
+                dir_path.mkdir(exist_ok=True)
                 return str(dir_path)
             except Exception as e:
                 self.logger.error(f"Could not create the subsample directory: {e}")


### PR DESCRIPTION
Encountered an odd error during a run yesterday where oracle crashed because the subsample directory had already been made.

This is a simple fix to prevent oracle from crashing unnecessarily if the folder has already been made. I'm guessing the only situation in which this could possibly happen is some PyQt thread race condition...but I've never seen this happen before.