### PR TITLE
Pressure limiting flow control

### DIFF
--- a/ulc_mm_package/hardware/real/pneumatic_module.py
+++ b/ulc_mm_package/hardware/real/pneumatic_module.py
@@ -260,6 +260,7 @@ class AdafruitMPRLS:
         self.mprls_pwr_pin = mprls_pwr_pin
         self.prev_poll_time_s: float = 0.0
         self.prev_pressure: float = 0.0
+        self.ambient_pressure: float = 0.0
         self.prev_status = PressureSensorRead.ALL_GOOD
 
         self.io_error_counter = 0

--- a/ulc_mm_package/hardware/scope_routines.py
+++ b/ulc_mm_package/hardware/scope_routines.py
@@ -410,6 +410,9 @@ class Routines:
         except PressureSensorBusy:
             raise
 
+        mscope.pneumatic_module.mpr.ambient_pressure = ambient_pressure
+        mscope.pneumatic_module.mpr.final_pressure = final_pressure
+
         # Check if there is a pressure leak
         pressure_diff = ambient_pressure - final_pressure
         if pressure_diff < MIN_PRESSURE_DIFF:

--- a/ulc_mm_package/image_processing/flow_control.py
+++ b/ulc_mm_package/image_processing/flow_control.py
@@ -8,6 +8,7 @@ from ulc_mm_package.image_processing.ewma_filtering_utils import EWMAFiltering
 from ulc_mm_package.image_processing.processing_constants import (
     FLOW_CONTROL_EWMA_ALPHA,
     TOL_PERC,
+    MAX_VACUUM_PRESSURE,
 )
 from ulc_mm_package.image_processing.flowrate import FlowRateEstimator
 
@@ -221,7 +222,10 @@ class FlowController:
         elif flow_error > 0:
             try:
                 # Increase pressure, move syringe down
-                if not self.pneumatic_module.is_locked():
+                pressure, _ = self.pneumatic_module.getPressure()
+                if not self.pneumatic_module.is_locked() and pressure > (
+                    self.pneumatic_module.mpr.ambient_pressure - MAX_VACUUM_PRESSURE
+                ):
                     self.pneumatic_module.threadedDecreaseDutyCycle()
             except SyringeEndOfTravel:
                 raise CantReachTargetFlowrate(self.flowrate)

--- a/ulc_mm_package/image_processing/processing_constants.py
+++ b/ulc_mm_package/image_processing/processing_constants.py
@@ -32,6 +32,7 @@ INSIDE_BBOX_FLAG = 0
 FLOW_CONTROL_EWMA_ALPHA = 0.05
 TOL_PERC = 0.1
 FAILED_CORR_PERC_TOLERANCE = 0.75
+MAX_VACUUM_PRESSURE = 400  # mBar
 
 # Factor by which to multiply the ewma feebdack adjustment delay (in frames) to set the window size
 # of the past measurements to check for failed xcorrs.


### PR DESCRIPTION
Limit syringe motion based on max pressure. Aim is to avoid flow cell channel collapse if too much pressure is exerted