### PR TITLE
Parasitemia vis path removal hotfix

### DIFF
--- a/ulc_mm_package/QtGUI/oracle.py
+++ b/ulc_mm_package/QtGUI/oracle.py
@@ -767,7 +767,7 @@ class Oracle(Machine):
             buttons=Buttons.OK,
             image=parasitemia_vis_path,
         )
-        if Path(parasitemia_vis_path).exists():
+        if Path(parasitemia_vis_path).exists() and Path(parasitemia_vis_path).is_file():
             remove(parasitemia_vis_path)
 
         self.display_message(


### PR DESCRIPTION
Proper check to ensure that the parasitemia_vis_path given is a file before attempting to remove it.