### PR TITLE
Bugfix: Use the min necessary pressure during cell finder as opposed to the max allowable

### DIFF
--- a/ulc_mm_package/hardware/scope_routines.py
+++ b/ulc_mm_package/hardware/scope_routines.py
@@ -516,7 +516,7 @@ class Routines:
                     mscope.pneumatic_module.getAmbientPressure()
                     - mscope.pneumatic_module.getPressure()[0]
                 )
-                while curr_pressure_gauge < processing_constants.MAX_VACUUM_PRESSURE:
+                while curr_pressure_gauge < MIN_PRESSURE_DIFF:
                     # Pass in a flow_error=1.0 to pull the syringe down
                     try:
                         flow_controller.adjustSyringe(flow_error=1.0)


### PR DESCRIPTION
Attempt to draw the min necessary pressure as opposed to using the cap for max allowable during cell finder