### PR TITLE
NCS performance hint --> throughput + increase SSAF polling

### DIFF
--- a/ulc_mm_package/hardware/scope_routines.py
+++ b/ulc_mm_package/hardware/scope_routines.py
@@ -485,7 +485,9 @@ class Routines:
         # Maximum number of times to run check for cells routine before aborting
         max_attempts = 3
         cell_finder = CellFinder()
+        mscope.flow_controller.reset()
         flow_controller = mscope.flow_controller
+
         img = yield
 
         # Initial check for cells, return current motor position if cells found

--- a/ulc_mm_package/neural_nets/NCSModel.py
+++ b/ulc_mm_package/neural_nets/NCSModel.py
@@ -116,6 +116,9 @@ class NCSModel:
                 compiled_model = self.core.compile_model(
                     model,
                     self.device_name,
+                    config = {
+                        "PERFORMANCE_HINT": "THROUGHPUT",
+                    }
                 )
                 self.connected = True
                 return compiled_model

--- a/ulc_mm_package/neural_nets/NCSModel.py
+++ b/ulc_mm_package/neural_nets/NCSModel.py
@@ -116,9 +116,9 @@ class NCSModel:
                 compiled_model = self.core.compile_model(
                     model,
                     self.device_name,
-                    config = {
+                    config={
                         "PERFORMANCE_HINT": "THROUGHPUT",
-                    }
+                    },
                 )
                 self.connected = True
                 return compiled_model

--- a/ulc_mm_package/neural_nets/neural_network_constants.py
+++ b/ulc_mm_package/neural_nets/neural_network_constants.py
@@ -7,7 +7,7 @@ curr_dir = Path(__file__).parent.resolve()  # Get full path
 
 
 # ================ Autofocus constants ================ #
-AF_PERIOD_S = 0.1 # (10 imgs/sec)
+AF_PERIOD_S = 0.1  # (10 imgs/sec)
 AF_PERIOD_NUM = int(
     AF_PERIOD_S * ACQUISITION_FPS
 )  # Used for periodic (ie. EWMA) autofocus

--- a/ulc_mm_package/neural_nets/neural_network_constants.py
+++ b/ulc_mm_package/neural_nets/neural_network_constants.py
@@ -7,11 +7,11 @@ curr_dir = Path(__file__).parent.resolve()  # Get full path
 
 
 # ================ Autofocus constants ================ #
-AF_PERIOD_S = 0.5
+AF_PERIOD_S = 0.1
 AF_PERIOD_NUM = int(
     AF_PERIOD_S * ACQUISITION_FPS
 )  # Used for periodic (ie. EWMA) autofocus
-AF_BATCH_SIZE = 10  # Used for single shot autofocus
+AF_BATCH_SIZE = 50  # Used for single shot autofocus
 
 AF_THRESHOLD = 2
 AF_QSIZE = 10  # For AF_PERIOD_S = 0.5, we have a max delay of 5 sec

--- a/ulc_mm_package/neural_nets/neural_network_constants.py
+++ b/ulc_mm_package/neural_nets/neural_network_constants.py
@@ -7,14 +7,14 @@ curr_dir = Path(__file__).parent.resolve()  # Get full path
 
 
 # ================ Autofocus constants ================ #
-AF_PERIOD_S = 0.1
+AF_PERIOD_S = 0.1 # (10 imgs/sec)
 AF_PERIOD_NUM = int(
     AF_PERIOD_S * ACQUISITION_FPS
 )  # Used for periodic (ie. EWMA) autofocus
-AF_BATCH_SIZE = 50  # Used for single shot autofocus
+AF_BATCH_SIZE = 20  # Used for single shot autofocus
 
 AF_THRESHOLD = 2
-AF_QSIZE = 10  # For AF_PERIOD_S = 0.5, we have a max delay of 5 sec
+AF_QSIZE = 25
 
 AUTOFOCUS_MODEL_NAME = "fast-cosmos-557"
 AUTOFOCUS_MODEL_DIR = str(


### PR DESCRIPTION
OpenVINO (the library used to interface with the Neural Compute Stick 2) has a configuration parameter, `PERFORMANCE_HINT`, which can be set to `LATENCY` or `THROUGHPUT`. It is set to `LATENCY` be default, which prioritizes the immediacy of a result. 

With `LATENCY` mode, if we send an image, the NCS will prioritize getting a result back for that single image as soon as possbile. In contrast, `THROUGHPUT` mode trades off single-image inference time for faster batch-inference time. 

In essence, we might trade getting one SSAF result back every two cycles for getting five SSAF results every four cycles (these numbers are made up but illustrate the point). In this toy example, we have to wait two more frames before getting results, but get one extra data point than if we were using `LATENCY` mode.

I want to test empirically if and by how much we can increase what we send to the NCS using `THROUGHPUT` mode. If we can send a lot more images to SSAF, and the delay is inconsequential, and there are no increasing queues, we will come out ahead because we will be able to get a better read on the SSAF signal and track focus more quickly. Currently the EWMA filter is relatively conservative to account for how noisy the SSAF signal is, in part because of the infrequency with which get SSAF results.

Some more information about the NCS performance hint is here: 