### PR TITLE
Reset pneumatic module step size in the case where `fast_flow` fails

### DIFF
--- a/ulc_mm_package/hardware/real/pneumatic_module.py
+++ b/ulc_mm_package/hardware/real/pneumatic_module.py
@@ -75,8 +75,9 @@ class PneumaticModule:
         (
             self.min_duty_cycle,
             self.max_duty_cycle,
-            self.min_step_size,
+            self.default_min_step_size,
         ) = self.get_config_params()
+        self.min_step_size = self.default_min_step_size
 
         self.duty_cycle = self.max_duty_cycle
         self.prev_duty_cycle = self.duty_cycle


### PR DESCRIPTION
Context: We set the pneumatic module step size to be twice what it is normally when doing fast flow, so that the set up is quicker and more ergonomic for the user (i.e they don't need to wait for a long while for the syringe to hit its stop in the event that debris or stuck cells are messing up the flow estimation calculation. Fix: This properly resets the step size back to what it is normally supposed to be, in the event where fast flow does not reach the target flow rate. Previously it was only being reset when fast flow succeeded.