### PR TITLE
Add sample collection date+time, and storage temperature inputs to the experiment form.

### DIFF
--- a/ulc_mm_package/QtGUI/form_gui.py
+++ b/ulc_mm_package/QtGUI/form_gui.py
@@ -6,7 +6,6 @@ Takes user input and exports experiment metadata.
 
 import sys
 
-
 from PyQt5.QtWidgets import (
     QApplication,
     QDialog,
@@ -19,10 +18,11 @@ from PyQt5.QtWidgets import (
     QDesktopWidget,
 )
 from PyQt5.QtGui import QIcon
-from PyQt5.QtCore import pyqtSignal
+from PyQt5.QtCore import pyqtSignal, QDate, QTime
 
 from ulc_mm_package.scope_constants import EXPERIMENT_METADATA_KEYS
 from ulc_mm_package.image_processing.processing_constants import TARGET_FLOWRATE
+from PyQt5.QtWidgets import QDateEdit, QTimeEdit
 from ulc_mm_package.QtGUI.gui_constants import (
     ICON_PATH,
     SITE_LIST,
@@ -48,6 +48,15 @@ class FormGUI(QDialog):
         else:
             event.accept()
 
+    def _validate_temperature(self):
+        text = self.sample_storage_temp.text()
+        if not text.endswith(("C", "F")) or not text[:-1].isdigit():
+            self.sample_storage_temp.setStyleSheet("border: 1px solid red;")
+            self.start_btn.setEnabled(False)
+        else:
+            self.sample_storage_temp.setStyleSheet("")
+            self.start_btn.setEnabled(True)
+            
     def _load_ui(self):
         self.setWindowTitle("Experiment form")
 
@@ -78,6 +87,9 @@ class FormGUI(QDialog):
         # Labels
         self.operator_lbl = QLabel("Operator ID")
         self.participant_lbl = QLabel("Non-identifying participant ID")
+        self.sample_collection_date_lbl = QLabel("Sample collection date")
+        self.sample_collection_time_lbl = QLabel("Sample collection time")
+        self.sample_storage_temp_lbl = QLabel("Sample storage temperature (°C or °F)")
         self.flowcell_lbl = QLabel("Flowcell ID")
         self.notes_lbl = QLabel("Other notes")
         self.site_lbl = QLabel("Site")
@@ -87,6 +99,22 @@ class FormGUI(QDialog):
         # Text boxes
         self.operator_val = QLineEdit()
         self.participant_val = QLineEdit()
+
+        # Sample collection date
+        self.sample_collection_date = QDateEdit(QDate.currentDate())
+        self.sample_collection_date.setCalendarPopup(True)
+        self.sample_collection_date.setDisplayFormat("yyyy-MMM-dd")
+
+        # Sample collection time
+        self.sample_collection_time = QTimeEdit(QTime.currentTime())
+        self.sample_collection_time.setDisplayFormat("hh:mm AP")
+        self.sample_collection_time.setCalendarPopup(True)
+
+        # Sample storage temperature
+        self.sample_storage_temp = QLineEdit()
+        self.sample_storage_temp.setPlaceholderText("Enter temperature (e.g. 25C or 77F)")
+        self.sample_storage_temp.textChanged.connect(self._validate_temperature)
+
         self.flowcell_val = QLineEdit()
         self.notes_val = QPlainTextEdit()
 
@@ -107,21 +135,27 @@ class FormGUI(QDialog):
         # Place widgets
         self.main_layout.addWidget(self.operator_lbl, 0, 0)
         self.main_layout.addWidget(self.participant_lbl, 1, 0)
-        self.main_layout.addWidget(self.flowcell_lbl, 2, 0)
-        self.main_layout.addWidget(self.site_lbl, 4, 0)
-        self.main_layout.addWidget(self.sample_lbl, 5, 0)
-        self.main_layout.addWidget(self.notes_lbl, 6, 0)
-        self.main_layout.addWidget(self.exit_btn, 8, 0)
+        self.main_layout.addWidget(self.sample_collection_date_lbl, 2, 0)
+        self.main_layout.addWidget(self.sample_collection_time_lbl, 3, 0)
+        self.main_layout.addWidget(self.sample_storage_temp_lbl, 4, 0)
+        self.main_layout.addWidget(self.flowcell_lbl, 5, 0)
+        self.main_layout.addWidget(self.site_lbl, 6, 0)
+        self.main_layout.addWidget(self.sample_lbl, 7, 0)
+        self.main_layout.addWidget(self.notes_lbl, 8, 0)
+        self.main_layout.addWidget(self.exit_btn, 9, 0)
 
         self.main_layout.addWidget(self.operator_val, 0, 1)
         self.main_layout.addWidget(self.participant_val, 1, 1)
-        self.main_layout.addWidget(self.flowcell_val, 2, 1)
-        self.main_layout.addWidget(self.site_val, 4, 1)
-        self.main_layout.addWidget(self.sample_val, 5, 1)
-        self.main_layout.addWidget(self.notes_val, 6, 1)
-        self.main_layout.addWidget(self.start_btn, 8, 1)
+        self.main_layout.addWidget(self.sample_collection_date, 2, 1)
+        self.main_layout.addWidget(self.sample_collection_time, 3, 1)
+        self.main_layout.addWidget(self.sample_storage_temp, 4, 1)
+        self.main_layout.addWidget(self.flowcell_val, 5, 1)
+        self.main_layout.addWidget(self.site_val, 6, 1)
+        self.main_layout.addWidget(self.sample_val, 7, 1)
+        self.main_layout.addWidget(self.notes_val, 8, 1)
+        self.main_layout.addWidget(self.start_btn, 9, 1)
 
-        self.main_layout.addWidget(self.msg_lbl, 7, 0, 1, 2)
+        self.main_layout.addWidget(self.msg_lbl, 10, 0, 1, 2)
 
         # Set the focus order
         self.operator_val.setFocus()
@@ -156,6 +190,7 @@ class FormGUI(QDialog):
 if __name__ == "__main__":
     app = QApplication(sys.argv)
     gui = FormGUI()
+    gui.exit_btn.clicked.connect(gui.close)
 
     print(gui.get_form_input())
 

--- a/ulc_mm_package/QtGUI/form_gui.py
+++ b/ulc_mm_package/QtGUI/form_gui.py
@@ -56,7 +56,7 @@ class FormGUI(QDialog):
         else:
             self.sample_storage_temp.setStyleSheet("")
             self.start_btn.setEnabled(True)
-            
+
     def _load_ui(self):
         self.setWindowTitle("Experiment form")
 
@@ -112,7 +112,9 @@ class FormGUI(QDialog):
 
         # Sample storage temperature
         self.sample_storage_temp = QLineEdit()
-        self.sample_storage_temp.setPlaceholderText("Enter temperature (e.g. 25C or 77F)")
+        self.sample_storage_temp.setPlaceholderText(
+            "Enter temperature (e.g. 25C or 77F)"
+        )
         self.sample_storage_temp.textChanged.connect(self._validate_temperature)
 
         self.flowcell_val = QLineEdit()

--- a/ulc_mm_package/QtGUI/form_gui.py
+++ b/ulc_mm_package/QtGUI/form_gui.py
@@ -50,7 +50,7 @@ class FormGUI(QDialog):
 
     def _validate_temperature(self):
         text = self.sample_storage_temp.text()
-        if not text.endswith(("C", "F")) or not text[:-1].isdigit():
+        if not text.endswith(("C", "F", "c", "f")) or not text[:-1].isdigit():
             self.sample_storage_temp.setStyleSheet("border: 1px solid red;")
             self.start_btn.setEnabled(False)
         else:
@@ -168,6 +168,9 @@ class FormGUI(QDialog):
             "operator_id": self.operator_val.text(),
             "participant_id": self.participant_val.text(),
             "flowcell_id": self.flowcell_val.text(),
+            "sample_collection_date": self.sample_collection_date.text(),
+            "sample_collection_time": self.sample_collection_time.text(),
+            "sample_storage_temp": self.sample_storage_temp.text(),
             "target_flowrate": (
                 TARGET_FLOWRATE.name.capitalize(),
                 TARGET_FLOWRATE.value,

--- a/ulc_mm_package/scope_constants.py
+++ b/ulc_mm_package/scope_constants.py
@@ -145,6 +145,9 @@ except usb.core.NoBackendError:
 EXPERIMENT_METADATA_KEYS = [
     "operator_id",
     "participant_id",
+    "sample_collection_date",
+    "sample_collection_time",
+    "sample_storage_temp",
     "flowcell_id",
     "target_flowrate",
     "site",


### PR DESCRIPTION
There are now inputs for entering the date (yyyy-mm-dd) and time (hh-mm), and storage temperature.

I added a little validation check to the storage temperature so that if an incorrect input is entered (i.e does not following the format of 25C or 77F, for example), then the start button is disabled. But, this check is only done at the moment after a user makes an input. I left it this way, as opposed to having the start button disabled from the get-go, so that in cases where we don't care about the storage temperature it is less of a nuisance to do repeated runs.

Example images below:

<img width="667" alt="image" src="https://github.com/user-attachments/assets/be69179f-a895-4164-babd-0379e6d35aad" />


<img width="670" alt="image" src="https://github.com/user-attachments/assets/f864fdca-990c-4072-a9fa-63dd674a2dcc" />
