### PR TITLE
Calculate and store sample age

### DIFF
--- a/ulc_mm_package/QtGUI/form_gui.py
+++ b/ulc_mm_package/QtGUI/form_gui.py
@@ -156,7 +156,6 @@ class FormGUI(QDialog):
         self.main_layout.addWidget(self.notes_val, 8, 1)
         self.main_layout.addWidget(self.start_btn, 9, 1)
 
-
         # Set the focus order
         self.operator_val.setFocus()
         self.start_btn.setDefault(True)

--- a/ulc_mm_package/QtGUI/form_gui.py
+++ b/ulc_mm_package/QtGUI/form_gui.py
@@ -94,7 +94,6 @@ class FormGUI(QDialog):
         self.notes_lbl = QLabel("Other notes")
         self.site_lbl = QLabel("Site")
         self.sample_lbl = QLabel("Sample type")
-        self.msg_lbl = QLabel("Please fill out experiment data.")
 
         # Text boxes
         self.operator_val = QLineEdit()
@@ -157,7 +156,6 @@ class FormGUI(QDialog):
         self.main_layout.addWidget(self.notes_val, 8, 1)
         self.main_layout.addWidget(self.start_btn, 9, 1)
 
-        self.main_layout.addWidget(self.msg_lbl, 10, 0, 1, 2)
 
         # Set the focus order
         self.operator_val.setFocus()

--- a/ulc_mm_package/QtGUI/form_gui.py
+++ b/ulc_mm_package/QtGUI/form_gui.py
@@ -164,12 +164,25 @@ class FormGUI(QDialog):
         self.start_btn.setDefault(True)
 
     def get_form_input(self) -> dict:
+        # Determine the sample age from the current time and the sample collection time
+        current_date = QDate.currentDate()
+        current_time = QTime.currentTime()
+
+        sample_date = self.sample_collection_date.date()
+        sample_time = self.sample_collection_time.time()
+
+        date_diff_in_hours = sample_date.daysTo(current_date) * 24
+        time_diff_in_hours = sample_time.secsTo(current_time) / 3600
+
+        sample_age_hours = date_diff_in_hours + time_diff_in_hours
+
         form_metadata = {
             "operator_id": self.operator_val.text(),
             "participant_id": self.participant_val.text(),
             "flowcell_id": self.flowcell_val.text(),
             "sample_collection_date": self.sample_collection_date.text(),
             "sample_collection_time": self.sample_collection_time.text(),
+            "sample_age_hours": sample_age_hours,
             "sample_storage_temp": self.sample_storage_temp.text(),
             "target_flowrate": (
                 TARGET_FLOWRATE.name.capitalize(),

--- a/ulc_mm_package/QtGUI/form_gui.py
+++ b/ulc_mm_package/QtGUI/form_gui.py
@@ -174,7 +174,7 @@ class FormGUI(QDialog):
         date_diff_in_hours = sample_date.daysTo(current_date) * 24
         time_diff_in_hours = sample_time.secsTo(current_time) / 3600
 
-        sample_age_hours = date_diff_in_hours + time_diff_in_hours
+        sample_age_hours = round(date_diff_in_hours + time_diff_in_hours, 2)
 
         form_metadata = {
             "operator_id": self.operator_val.text(),

--- a/ulc_mm_package/scope_constants.py
+++ b/ulc_mm_package/scope_constants.py
@@ -147,6 +147,7 @@ EXPERIMENT_METADATA_KEYS = [
     "participant_id",
     "sample_collection_date",
     "sample_collection_time",
+    "sample_age_hours",
     "sample_storage_temp",
     "flowcell_id",
     "target_flowrate",


### PR DESCRIPTION
The user enters the sample collection date and time already. This PR adds a small convenience for us by automatically calculating the sample age and storing it in the experiment metadata file.