### PR TITLE
Logging fixes

### DIFF
--- a/ulc_mm_package/QtGUI/oracle.py
+++ b/ulc_mm_package/QtGUI/oracle.py
@@ -368,7 +368,7 @@ class Oracle(Machine):
             sys.exit(1)
 
     def ssd_full_msg_and_exit(self):
-        self.logger.error(
+        print(
             "Couldn't find any folders in /media/pi with sufficient storage. Please eject and replace the SSD with a new one. Thank you!"
         )
         self.display_message(

--- a/ulc_mm_package/QtGUI/scope_op.py
+++ b/ulc_mm_package/QtGUI/scope_op.py
@@ -1083,7 +1083,7 @@ class ScopeOp(QObject, NamedMachine):
 
         if self.frame_count % FRAME_LOG_INTERVAL == 0:
             # Log full periodic metadata
-            self.logger.info(
+            self.logger.debug(
                 f"[Frame {self.frame_count}] Full periodic metadata: {self.periodic_log_values}"
             )
 

--- a/ulc_mm_package/logger.config
+++ b/ulc_mm_package/logger.config
@@ -8,7 +8,7 @@ keys=fileHandler, printHandler
 keys=stringFormatter, printFormatter
 
 [logger_root]
-level=INFO
+level=DEBUG
 handlers=fileHandler, printHandler
 
 [logger_transitionscore]
@@ -21,7 +21,7 @@ propagate=0
 class=FileHandler
 args=('%(filename)s', 'a')
 formatter=stringFormatter
-level=%(fileHandlerLevel)s
+level=DEBUG
 
 [handler_printHandler]
 class=StreamHandler


### PR DESCRIPTION
Set fileHandler default to DEBUG and printHandler to INFO. This removes clutter on terminal screen. 
Fixed no SSD crash.