### PR TITLE
Logging fixes

### DIFF
--- a/OS_instructions/setup_promtail.sh
+++ b/OS_instructions/setup_promtail.sh
@@ -131,7 +131,7 @@ After=network-online.target
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/promtail-retry.sh
-Restart=
+Restart=always
 RestartSec=10
 User=pi
 Environment="HOSTNAME=${HOST}"

--- a/OS_instructions/setup_promtail.sh
+++ b/OS_instructions/setup_promtail.sh
@@ -126,20 +126,20 @@ sudo chmod +x "$WRAPPER"
 sudo tee /etc/systemd/system/promtail.service > /dev/null <<'EOF'
 [Unit]
 Description=Promtail (logs on removable SSD)
-After=network-online.target     # wait for network
+After=network-online.target
 BindsTo=media-pi-SamsungSSD.mount
 PartOf=media-pi-SamsungSSD.mount
 
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/promtail-retry.sh
-Restart=on-failure              # try again when wrapper exits with code 1
+Restart=on-failure
 RestartSec=10
 User=pi
 Environment="HOSTNAME=${HOST}"
 Environment="LOKI_PASSWORD=${PASSWORD}"
 KillMode=mixed
-ExecStopPost=/bin/sync          # flush positions.yaml just in case
+ExecStopPost=/bin/sync
 
 [Install]
 WantedBy=multi-user.target

--- a/OS_instructions/setup_promtail.sh
+++ b/OS_instructions/setup_promtail.sh
@@ -54,7 +54,7 @@ cat << 'EOF' > "$CONFIG_FILE"
 server:
   disable: true  # Disables Promtail's internal HTTP server
 positions:
-  filename: /home/pi/Documents/ulc-malaria-scope/log_config/positions.yaml  # Stores file tracking state
+  filename: /media/pi/SamsungSSD//positions.yaml  # Stores file tracking state
   sync_period: 10s
 clients:
   - url: https://api-grafana.sf.czbiohub.org/loki/push
@@ -71,14 +71,14 @@ scrape_configs:
       host: ${HOSTNAME}
       __path__: /media/pi/SamsungSSD/logs/*.log  # Watches all logs in this directory
   pipeline_stages:
-  - labeldrop:
-    - filename
   - match:
       selector: '{app="Remoscope"}'
       stages:
       - multiline:
           firstline: '^\\d{4}-\\d{2}-\\d{2}-\\d{6} .*'
-          max_wait_time: 5s
+          max_wait_time: 20s
+      - labeldrop:
+          - filename
       - regex:
           expression: '^\\d{4}-\\d{2}-\\d{2}-\\d{6} - (?P<severity>\\w+) - .*'
       - labels:
@@ -103,6 +103,7 @@ echo "Creating systemd service file for promtail..."
 sudo tee /etc/systemd/system/promtail.service > /dev/null <<'EOF'
 [Unit]
 Description=Promtail Service
+RequiresMountsFor=/media/pi/SamsungSSD  
 After=network.target
 
 [Service]

--- a/OS_instructions/setup_promtail.sh
+++ b/OS_instructions/setup_promtail.sh
@@ -100,26 +100,46 @@ sudo mv /tmp/promtail-linux-arm /usr/local/bin/promtail
 
 echo "Creating Promtail systemd unit…"
 
-sudo tee /etc/systemd/system/promtail.service > /dev/null << 'EOF'
+# --- STEP 4: wrapper that exits (and lets systemd retry) --------------------
+WRAPPER="/usr/local/bin/promtail-retry.sh"
+echo "Creating wrapper script at $WRAPPER…"
+
+sudo tee "$WRAPPER" > /dev/null <<'EOF'
+#!/bin/bash
+SSD_DIR="/media/pi/SamsungSSD"
+
+# If the drive isn't mounted yet - retry
+if ! mountpoint -q "$SSD_DIR"; then
+  echo "Promtail: $SSD_DIR not mounted yet, exiting so systemd can retry…" >&2
+  exit 1
+fi
+
+exec /usr/local/bin/promtail \
+     --config.file=/home/pi/Documents/ulc-malaria-scope/log_config/promtail-config.yaml \
+     --config.expand-env=true
+EOF
+
+sudo chmod +x "$WRAPPER"
+
+# --- STEP 5: promtail-service file setup --------------------
+
+sudo tee /etc/systemd/system/promtail.service > /dev/null <<'EOF'
 [Unit]
 Description=Promtail (logs on removable SSD)
-After=network-online.target media-pi-SamsungSSD.mount
-RequiresMountsFor=/media/pi/SamsungSSD          # don't start without the SSD
-BindsTo=media-pi-SamsungSSD.mount               # stop immediately when un-mounted
-PartOf=media-pi-SamsungSSD.mount                # follow 'systemctl stop …mount'
+After=network-online.target     # wait for network
+BindsTo=media-pi-SamsungSSD.mount
+PartOf=media-pi-SamsungSSD.mount
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/promtail \
-          --config.file=/home/pi/Documents/ulc-malaria-scope/log_config/promtail-config.yaml \
-          --config.expand-env=true
+ExecStart=/usr/local/bin/promtail-retry.sh
+Restart=on-failure              # try again when wrapper exits with code 1
+RestartSec=10
+User=pi
 Environment="HOSTNAME=${HOST}"
 Environment="LOKI_PASSWORD=${PASSWORD}"
-User=pi
-Restart=on-failure
-RestartSec=5
-KillMode=mixed          # be sure children are killed
-ExecStopPost=/bin/sync  # flush positions.yaml before the drive vanishes
+KillMode=mixed
+ExecStopPost=/bin/sync          # flush positions.yaml just in case
 
 [Install]
 WantedBy=multi-user.target

--- a/OS_instructions/setup_promtail.sh
+++ b/OS_instructions/setup_promtail.sh
@@ -127,13 +127,11 @@ sudo tee /etc/systemd/system/promtail.service > /dev/null <<'EOF'
 [Unit]
 Description=Promtail (logs on removable SSD)
 After=network-online.target
-BindsTo=media-pi-SamsungSSD.mount
-PartOf=media-pi-SamsungSSD.mount
 
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/promtail-retry.sh
-Restart=on-failure
+Restart=
 RestartSec=10
 User=pi
 Environment="HOSTNAME=${HOST}"

--- a/OS_instructions/setup_promtail.sh
+++ b/OS_instructions/setup_promtail.sh
@@ -54,7 +54,7 @@ cat << 'EOF' > "$CONFIG_FILE"
 server:
   disable: true  # Disables Promtail's internal HTTP server
 positions:
-  filename: /media/pi/SamsungSSD//positions.yaml  # Stores file tracking state
+  filename: /media/pi/SamsungSSD/positions.yaml  # Stores file tracking state
   sync_period: 10s
 clients:
   - url: https://api-grafana.sf.czbiohub.org/loki/push

--- a/OS_instructions/setup_promtail.sh
+++ b/OS_instructions/setup_promtail.sh
@@ -98,19 +98,36 @@ echo "Making promtail executable and moving it to /usr/local/bin..."
 chmod +x /tmp/promtail-linux-arm
 sudo mv /tmp/promtail-linux-arm /usr/local/bin/promtail
 
-# --- Step 4: Create systemd service for Promtail using sed for environment variable substitution ---
-echo "Creating systemd service file for promtail..."
-sudo tee /etc/systemd/system/promtail.service > /dev/null <<'EOF'
+# --- Step 4: Create wrapper script to wait for SSD mount ---
+WRAPPER="/usr/local/bin/promtail-retry.sh"
+echo "Creating wrapper script at $WRAPPER..."
+
+sudo tee "$WRAPPER" > /dev/null << 'EOF'
+#!/bin/bash
+# Wait for SSD mount before launching promtail
+LOG_PATH="/media/pi/SamsungSSD/logs"
+while [ ! -d "$LOG_PATH" ]; do
+  echo "Waiting for $LOG_PATH to be available..."
+  sleep 10
+done
+exec /usr/local/bin/promtail --config.file=/home/pi/Documents/ulc-malaria-scope/log_config/promtail-config.yaml --config.expand-env=true
+EOF
+
+sudo chmod +x "$WRAPPER"
+
+# --- Step 5: Create systemd service ---
+echo "Creating systemd service file..."
+sudo tee /etc/systemd/system/promtail.service > /dev/null << EOF
 [Unit]
 Description=Promtail Service
-RequiresMountsFor=/media/pi/SamsungSSD
-BindsTo=media-pi-SamsungSSD.mount
-After=network.target
+After=network.target media-pi-SamsungSSD.mount
+Wants=media-pi-SamsungSSD.mount
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/promtail --config.file=/home/pi/Documents/ulc-malaria-scope/log_config/promtail-config.yaml --config.expand-env=true
-Restart=on-failure
+ExecStart=$WRAPPER
+Restart=always
+RestartSec=10
 User=pi
 Environment="HOSTNAME=HOST_PLACEHOLDER"
 Environment="LOKI_PASSWORD=PASSWORD_PLACEHOLDER"

--- a/OS_instructions/setup_promtail.sh
+++ b/OS_instructions/setup_promtail.sh
@@ -134,8 +134,8 @@ ExecStart=/usr/local/bin/promtail-retry.sh
 Restart=always
 RestartSec=10
 User=pi
-Environment="HOSTNAME=${HOST}"
-Environment="LOKI_PASSWORD=${PASSWORD}"
+Environment="HOSTNAME=HOST_PLACEHOLDER"
+Environment="LOKI_PASSWORD=PASSWORD_PLACEHOLDER"
 KillMode=mixed
 ExecStopPost=/bin/sync
 

--- a/OS_instructions/setup_promtail.sh
+++ b/OS_instructions/setup_promtail.sh
@@ -98,43 +98,33 @@ echo "Making promtail executable and moving it to /usr/local/bin..."
 chmod +x /tmp/promtail-linux-arm
 sudo mv /tmp/promtail-linux-arm /usr/local/bin/promtail
 
-# --- Step 4: Create wrapper script to wait for SSD mount ---
-WRAPPER="/usr/local/bin/promtail-retry.sh"
-echo "Creating wrapper script at $WRAPPER..."
+echo "Creating Promtail systemd unit…"
 
-sudo tee "$WRAPPER" > /dev/null << 'EOF'
-#!/bin/bash
-# Wait for SSD mount before launching promtail
-LOG_PATH="/media/pi/SamsungSSD/logs"
-while [ ! -d "$LOG_PATH" ]; do
-  echo "Waiting for $LOG_PATH to be available..."
-  sleep 10
-done
-exec /usr/local/bin/promtail --config.file=/home/pi/Documents/ulc-malaria-scope/log_config/promtail-config.yaml --config.expand-env=true
-EOF
-
-sudo chmod +x "$WRAPPER"
-
-# --- Step 5: Create systemd service ---
-echo "Creating systemd service file..."
-sudo tee /etc/systemd/system/promtail.service > /dev/null << EOF
+sudo tee /etc/systemd/system/promtail.service > /dev/null << 'EOF'
 [Unit]
-Description=Promtail Service
-After=network.target media-pi-SamsungSSD.mount
-Wants=media-pi-SamsungSSD.mount
+Description=Promtail (logs on removable SSD)
+After=network-online.target media-pi-SamsungSSD.mount
+RequiresMountsFor=/media/pi/SamsungSSD          # don't start without the SSD
+BindsTo=media-pi-SamsungSSD.mount               # stop immediately when un-mounted
+PartOf=media-pi-SamsungSSD.mount                # follow 'systemctl stop …mount'
 
 [Service]
 Type=simple
-ExecStart=$WRAPPER
-Restart=always
-RestartSec=10
+ExecStart=/usr/local/bin/promtail \
+          --config.file=/home/pi/Documents/ulc-malaria-scope/log_config/promtail-config.yaml \
+          --config.expand-env=true
+Environment="HOSTNAME=${HOST}"
+Environment="LOKI_PASSWORD=${PASSWORD}"
 User=pi
-Environment="HOSTNAME=HOST_PLACEHOLDER"
-Environment="LOKI_PASSWORD=PASSWORD_PLACEHOLDER"
+Restart=on-failure
+RestartSec=5
+KillMode=mixed          # be sure children are killed
+ExecStopPost=/bin/sync  # flush positions.yaml before the drive vanishes
 
 [Install]
 WantedBy=multi-user.target
 EOF
+
 
 echo "Updating systemd service file with provided HOST and PASSWORD..."
 sudo sed -i "s/Environment=\"HOSTNAME=HOST_PLACEHOLDER\"/Environment=\"HOSTNAME=${HOST}\"/" /etc/systemd/system/promtail.service
@@ -156,6 +146,25 @@ sudo systemctl daemon-reload
 echo "Enabling promtail service..."
 sudo systemctl enable promtail.service
 echo "Starting promtail service..."
+
+# --- STEP 6: Install udev rule for hard-pull safety --------------------------
+echo "Adding udev rule to stop promtail on drive removal…"
+
+sudo tee /etc/udev/rules.d/99-stop-promtail.rules > /dev/null <<'EOF'
+# Stop Promtail if the SSD (label SamsungSSD) is yanked.
+# ACTION=="remove"
+# SUBSYSTEM=="block"
+# ENV{ID_FS_LABEL}
+ACTION=="remove", SUBSYSTEM=="block", ENV{ID_FS_LABEL}=="SamsungSSD", \
+    RUN+="/bin/sync", RUN+="/usr/bin/systemctl stop promtail.service"
+EOF
+
+# Reload udev so the new rule is active immediately
+sudo udevadm control --reload
+sudo udevadm trigger --subsystem-match=block  # optional: re-evaluate current devices
+
+echo "udev rule installed - Promtail will shut down if the SSD is hard-pulled."
+
 sudo systemctl start promtail.service
 
 echo "Promtail setup complete."

--- a/OS_instructions/setup_promtail.sh
+++ b/OS_instructions/setup_promtail.sh
@@ -168,14 +168,13 @@ echo "Starting promtail service..."
 # --- STEP 6: Install udev rule for hard-pull safety --------------------------
 echo "Adding udev rule to stop promtail on drive removal…"
 
-sudo tee /etc/udev/rules.d/99-stop-promtail.rules > /dev/null <<'EOF'
-# Stop Promtail if the SSD (label SamsungSSD) is yanked.
-# ACTION=="remove"
-# SUBSYSTEM=="block"
-# ENV{ID_FS_LABEL}
+sudo tee /etc/udev/rules.d/99-promtail-ssd.rules > /dev/null <<'EOF'
 ACTION=="remove", SUBSYSTEM=="block", ENV{ID_FS_LABEL}=="SamsungSSD", \
-    RUN+="/bin/sync", RUN+="/usr/bin/systemctl stop promtail.service"
+    RUN+="/usr/bin/systemctl stop promtail.service"
+ACTION=="add", SUBSYSTEM=="block", ENV{ID_FS_LABEL}=="SamsungSSD", \
+    RUN+="/usr/bin/systemctl start promtail.service"
 EOF
+sudo udevadm control --reload
 
 # Reload udev so the new rule is active immediately
 sudo udevadm control --reload

--- a/OS_instructions/setup_promtail.sh
+++ b/OS_instructions/setup_promtail.sh
@@ -103,7 +103,8 @@ echo "Creating systemd service file for promtail..."
 sudo tee /etc/systemd/system/promtail.service > /dev/null <<'EOF'
 [Unit]
 Description=Promtail Service
-RequiresMountsFor=/media/pi/SamsungSSD  
+RequiresMountsFor=/media/pi/SamsungSSD
+BindsTo=media-pi-SamsungSSD.mount
 After=network.target
 
 [Service]

--- a/ulc_mm_package/QtGUI/oracle.py
+++ b/ulc_mm_package/QtGUI/oracle.py
@@ -368,7 +368,7 @@ class Oracle(Machine):
             sys.exit(1)
 
     def ssd_full_msg_and_exit(self):
-        self.logger.error(
+        print(
             "Couldn't find any folders in /media/pi with sufficient storage. Please eject and replace the SSD with a new one. Thank you!"
         )
         self.display_message(

--- a/ulc_mm_package/QtGUI/scope_op.py
+++ b/ulc_mm_package/QtGUI/scope_op.py
@@ -1083,7 +1083,7 @@ class ScopeOp(QObject, NamedMachine):
 
         if self.frame_count % FRAME_LOG_INTERVAL == 0:
             # Log full periodic metadata
-            self.logger.info(
+            self.logger.debug(
                 f"[Frame {self.frame_count}] Full periodic metadata: {self.periodic_log_values}"
             )
 

--- a/ulc_mm_package/logger.config
+++ b/ulc_mm_package/logger.config
@@ -8,7 +8,7 @@ keys=fileHandler, printHandler
 keys=stringFormatter, printFormatter
 
 [logger_root]
-level=INFO
+level=DEBUG
 handlers=fileHandler, printHandler
 
 [logger_transitionscore]
@@ -21,7 +21,7 @@ propagate=0
 class=FileHandler
 args=('%(filename)s', 'a')
 formatter=stringFormatter
-level=%(fileHandlerLevel)s
+level=DEBUG
 
 [handler_printHandler]
 class=StreamHandler


### PR DESCRIPTION

Traceback alerts on Grafana should have the entire traceback now.
- We name our log files by date. Promtail automatically generates a filename label that can be sorted in Loki. The filename has high cardinality and would reduce performance of Loki so it was dropped. However, this caused the stream of log files to become interwoven with each other. This caused a race condition when many logs were uploaded at once and pieces of traceback messages would be come attached to random other log files. Before the filename label was immediately dropped. Now, the filename label is dropped after the multiline processing of a log message. This allows for an entire traceback message to be grouped together and sent into the stream of log messages before the filename label is dropped. 


SSDs can now be swapped between devices without re-uploading logs. 
- There were some issues with the log tracking files becoming corrupted and the promtail service not starting properly. This is why I initially had the tracking files on the device rather than the SSD. This should be fixed now. 
- There is a wrapper service that will try to restart promtail when an SSD is not connected. 
- The positions.yaml file is now placed on the SSD. 
- When the SSD is unplugged it stops the promtail service which causes the wrapper service to start and wait for the SSD to become connected.
- Added a command to flush the positions.yaml file and quit the promtail service when the SSD is forcibly ejected. The positions.yaml file no longer corrupts. 