### PR TITLE
Relaxing motor stepping threshold (2 steps --> 1.5)

### DIFF
--- a/ulc_mm_package/hardware/hardware_constants.py
+++ b/ulc_mm_package/hardware/hardware_constants.py
@@ -6,7 +6,7 @@ RPI_OUTPUT_V = 3.3
 BOARD_STATUS_INDICATOR = 4
 
 # ================ EWMA filter constants ================ #
-FOCUS_EWMA_ALPHA = 0.05
+FOCUS_EWMA_ALPHA = 0.1
 
 # ================ Camera constants ================ #
 DEFAULT_EXPOSURE_MS = 0.5

--- a/ulc_mm_package/neural_nets/neural_network_constants.py
+++ b/ulc_mm_package/neural_nets/neural_network_constants.py
@@ -13,7 +13,7 @@ AF_PERIOD_NUM = int(
 )  # Used for periodic (ie. EWMA) autofocus
 AF_BATCH_SIZE = 20  # Used for single shot autofocus
 
-AF_THRESHOLD = 2
+AF_THRESHOLD = 1.5
 AF_QSIZE = 25
 
 AUTOFOCUS_MODEL_NAME = "fast-cosmos-557"


### PR DESCRIPTION
Relax the threshold for when a motor adjustment is taken based on the filtered focus error (dropping from 2 steps to 1.5)