### PR TITLE
Explicitly reset Autobrightnesss class after every autobrightness call

### DIFF
--- a/ulc_mm_package/utilities/zstack_utility.py
+++ b/ulc_mm_package/utilities/zstack_utility.py
@@ -519,6 +519,7 @@ def main():
         If the target brightness is not achieved, it will show a message box and return.
         """
         status_label.config(text="Adjusting LED brightness...")
+        logger.info("Adjusting LED brightness...")
         root.update()
 
         brightness_achieved = False

--- a/ulc_mm_package/utilities/zstack_utility.py
+++ b/ulc_mm_package/utilities/zstack_utility.py
@@ -526,11 +526,14 @@ def main():
             img, _ = next(camera.yieldImages())
             try:
                 brightness_achieved = autobrightness.runAutobrightness(img)
+                autobrightness.reset()
             except BrightnessTargetNotAchieved:
                 logger.info("Brightness target not achieved but usable. Proceeding...")
-                break
+                autobrightness.reset()
+                return
             except BrightnessCriticallyLow:
                 logger.info("Brightness critically low. Continuing anyway...")
+                autobrightness.reset()
                 return
 
     def start_sweep(n_steps: int = 20, imgs_per_step: int = 2):


### PR DESCRIPTION
This should not really make a tangible difference when performing multiple sweeps on the same chip. The autobrightness function is called before every local sweep so the motor positions should all have roughly the same illumination between sweeps. However for completeness and to be explicit - let's reset the Autobrightness manually after every call.