### PR TITLE
Rtc fix

### DIFF
--- a/OS_instructions/RTC/RTC_setup.md
+++ b/OS_instructions/RTC/RTC_setup.md
@@ -18,13 +18,25 @@ sudo chmod +x rc.local
 sudo chmod +x dhcpcd.exit-hook
 ```
 
+Finally, make sure the RTC runs off universal time by running
+```
+timedatectl set-local-rtc 0
+```
+
 ## Tests (optional)
 
 Reboot after adding the above files to start the RTC before testing.
 
-### RTC in use
+### RTC and I2C successully configured
 
-Verify system vs RTC time using `timedatectl` in terminal. You will see a printout like this:
+Ensure `i2c-tools` was installed and correctly setup by running
+```
+i2cdetect -y 1
+```
+
+The RTC should show up under bit `x68`. This bit should be marked as "UU" to indicate it's in use. This means `rc.local` succesfully ran and the RTC is currently being used.
+
+Somewhat redundant, but you can now verify system vs RTC time using `timedatectl` in terminal. You will see a printout like this:
 ```
                Local time: Mon 2025-08-25 15:42:07 PDT
            Universal time: Mon 2025-08-25 22:42:07 UTC

--- a/OS_instructions/RTC/dhcpcd.exit-hook
+++ b/OS_instructions/RTC/dhcpcd.exit-hook
@@ -7,7 +7,7 @@ if [ "$interface" = "wlan0" ]; then
   case "$reason" in
     BOUND|RENEW|REBIND|REBOOT)
       timedatectl set-ntp true
-      sleep(1)
+      sleep 1
       if timedatectl show -p NTPSynchronized | grep -q "yes"; then
         sudo hwclock --systohc --noadjfile --localtime
       fi

--- a/OS_instructions/RTC/dhcpcd.exit-hook
+++ b/OS_instructions/RTC/dhcpcd.exit-hook
@@ -2,20 +2,25 @@
 # Runs after dhcpcd processes a DHCP event.
 # Env vars available: $interface, $reason, $new_ip_address, $new_routers, etc.
 
-
-echo "$(date '+%Y-%m-%d %H:%M:%S') - DHCPCD reason $reason" >> ~/Desktop/rtc.log
-
-# Only act on Wi-Fi and only when we (re)obtained a lease
-if [ "$interface" = "wlan0" ]; then
-  case "$reason" in
-    BOUND|RENEW|REBIND|REBOOT)
-      timedatectl set-ntp true
-      sleep 1
-      if timedatectl show -p NTPSynchronized | grep -q "yes"; then
-        sudo hwclock --systohc --noadjfile --localtime
-        echo "$(date '+%Y-%m-%d %H:%M:%S') - DHCPCD update RTC from system time" >> ~/Desktop/rtc.log
-      else
-        echo "$(date '+%Y-%m-%d %H:%M:%S') - DHCPCD not synced" >> ~/Desktop/rtc.log
-      fi
-  esac
+if [ "${RTC_LOGGING:-}" = "1" ]; then
+  echo "$(date '+%Y-%m-%d %H:%M:%S') - DHCPCD $interface $reason" >> /home/pi/Desktop/rtc.log
 fi
+
+# Only act when wifi or ethernet (re)obtained a lease
+case "$reason" in
+  BOUND|RENEW|REBIND|REBOOT)
+    timedatectl set-ntp true
+    sleep 1
+    if timedatectl show -p NTPSynchronized | grep -q "yes"; then
+      # Update RTC from system time
+      sudo hwclock --systohc --noadjfile --utc
+
+      if [ "${RTC_LOGGING:-}" = "1" ]; then
+        echo "$(date '+%Y-%m-%d %H:%M:%S') - DHCPCD sync passed, updated RTC from system time" >> /home/pi/Desktop/rtc.log
+      fi
+    else	
+      if [ "${RTC_LOGGING:-}" = "1" ]; then
+        echo "$(date '+%Y-%m-%d %H:%M:%S') - DHCPCD sync failed, no RTC action" >> /home/pi/Desktop/rtc.log
+      fi
+    fi
+esac

--- a/OS_instructions/RTC/dhcpcd.exit-hook
+++ b/OS_instructions/RTC/dhcpcd.exit-hook
@@ -2,8 +2,6 @@
 # Runs after dhcpcd processes a DHCP event.
 # Env vars available: $interface, $reason, $new_ip_address, $new_routers, etc.
 
-echo "$(date '+%Y-%m-%d %H:%M:%S') - DHCPCD $interface $reason" >> /home/pi/Desktop/rtc.log
-
 # Only act when wifi or ethernet (re)obtained a lease
 case "$reason" in
   BOUND|RENEW|REBIND|REBOOT)
@@ -12,9 +10,5 @@ case "$reason" in
     if timedatectl show -p NTPSynchronized | grep -q "yes"; then
       # Update RTC from system time
       sudo hwclock --systohc --noadjfile --utc
-
-      echo "$(date '+%Y-%m-%d %H:%M:%S') - DHCPCD sync passed, updated RTC from system time" >> /home/pi/Desktop/rtc.log
-    else	
-      echo "$(date '+%Y-%m-%d %H:%M:%S') - DHCPCD sync failed, no RTC action" >> /home/pi/Desktop/rtc.log
     fi
 esac

--- a/OS_instructions/RTC/dhcpcd.exit-hook
+++ b/OS_instructions/RTC/dhcpcd.exit-hook
@@ -2,9 +2,7 @@
 # Runs after dhcpcd processes a DHCP event.
 # Env vars available: $interface, $reason, $new_ip_address, $new_routers, etc.
 
-if [ "${RTC_LOGGING:-}" = "1" ]; then
-  echo "$(date '+%Y-%m-%d %H:%M:%S') - DHCPCD $interface $reason" >> /home/pi/Desktop/rtc.log
-fi
+echo "$(date '+%Y-%m-%d %H:%M:%S') - DHCPCD $interface $reason" >> /home/pi/Desktop/rtc.log
 
 # Only act when wifi or ethernet (re)obtained a lease
 case "$reason" in
@@ -15,12 +13,8 @@ case "$reason" in
       # Update RTC from system time
       sudo hwclock --systohc --noadjfile --utc
 
-      if [ "${RTC_LOGGING:-}" = "1" ]; then
-        echo "$(date '+%Y-%m-%d %H:%M:%S') - DHCPCD sync passed, updated RTC from system time" >> /home/pi/Desktop/rtc.log
-      fi
+      echo "$(date '+%Y-%m-%d %H:%M:%S') - DHCPCD sync passed, updated RTC from system time" >> /home/pi/Desktop/rtc.log
     else	
-      if [ "${RTC_LOGGING:-}" = "1" ]; then
-        echo "$(date '+%Y-%m-%d %H:%M:%S') - DHCPCD sync failed, no RTC action" >> /home/pi/Desktop/rtc.log
-      fi
+      echo "$(date '+%Y-%m-%d %H:%M:%S') - DHCPCD sync failed, no RTC action" >> /home/pi/Desktop/rtc.log
     fi
 esac

--- a/OS_instructions/RTC/dhcpcd.exit-hook
+++ b/OS_instructions/RTC/dhcpcd.exit-hook
@@ -2,6 +2,9 @@
 # Runs after dhcpcd processes a DHCP event.
 # Env vars available: $interface, $reason, $new_ip_address, $new_routers, etc.
 
+
+echo "$(date '+%Y-%m-%d %H:%M:%S') - DHCPCD reason $reason" >> ~/Desktop/rtc.log
+
 # Only act on Wi-Fi and only when we (re)obtained a lease
 if [ "$interface" = "wlan0" ]; then
   case "$reason" in
@@ -10,6 +13,9 @@ if [ "$interface" = "wlan0" ]; then
       sleep 1
       if timedatectl show -p NTPSynchronized | grep -q "yes"; then
         sudo hwclock --systohc --noadjfile --localtime
+        echo "$(date '+%Y-%m-%d %H:%M:%S') - DHCPCD update RTC from system time" >> ~/Desktop/rtc.log
+      else
+        echo "$(date '+%Y-%m-%d %H:%M:%S') - DHCPCD not synced" >> ~/Desktop/rtc.log
       fi
   esac
 fi

--- a/OS_instructions/RTC/rc.local
+++ b/OS_instructions/RTC/rc.local
@@ -27,17 +27,13 @@ if timedatectl show -p NTPSynchronized | grep -q "yes"; then
   # Update RTC from system time
   sudo hwclock --systohc --noadjfile --utc
   
-  if [ "${RTC_LOGGING:-}" = "1" ]; then
-    echo "$(date '+%Y-%m-%d %H:%M:%S') - RCLOCAL sync passed, updated RTC from system time" >> /home/pi/Desktop/rtc.log
-  fi
+  echo "$(date '+%Y-%m-%d %H:%M:%S') - RCLOCAL sync passed, updated RTC from system time" >> /home/pi/Desktop/rtc.log
 else
   # Update system time from RTC
   timedatectl set-ntp false
   sudo hwclock -s
   
-  if [ "${RTC_LOGGING:-}" = "1" ]; then
-    echo "$(date '+%Y-%m-%d %H:%M:%S') - RCLOCAL sync failed, updated system time from RTC and turned off sync" >> /home/pi/Desktop/rtc.log
-  fi
+  echo "$(date '+%Y-%m-%d %H:%M:%S') - RCLOCAL sync failed, updated system time from RTC and turned off sync" >> /home/pi/Desktop/rtc.log
 fi
 
 exit 0

--- a/OS_instructions/RTC/rc.local
+++ b/OS_instructions/RTC/rc.local
@@ -26,14 +26,10 @@ sleep 1
 if timedatectl show -p NTPSynchronized | grep -q "yes"; then
   # Update RTC from system time
   sudo hwclock --systohc --noadjfile --utc
-  
-  echo "$(date '+%Y-%m-%d %H:%M:%S') - RCLOCAL sync passed, updated RTC from system time" >> /home/pi/Desktop/rtc.log
 else
   # Update system time from RTC
   timedatectl set-ntp false
   sudo hwclock -s
-  
-  echo "$(date '+%Y-%m-%d %H:%M:%S') - RCLOCAL sync failed, updated system time from RTC and turned off sync" >> /home/pi/Desktop/rtc.log
 fi
 
 exit 0

--- a/OS_instructions/RTC/rc.local
+++ b/OS_instructions/RTC/rc.local
@@ -26,11 +26,15 @@ sleep 1
 if timedatectl show -p NTPSynchronized | grep -q "yes"; then
   # Update RTC from system time
   sudo hwclock --systohc --noadjfile --localtime
+  echo "$(date '+%Y-%m-%d %H:%M:%S') - RCLOCAL update RTC from system time" >> ~/Desktop/rtc.log
+else
+  echo "$(date '+%Y-%m-%d %H:%M:%S') - RCLOCAL not synced" >> ~/Desktop/rtc.log
 fi
 
 # Always update system time from RTC!
 # For some reason this doesn't work in else statement
 timedatectl set-ntp false
 sudo hwclock -s
+echo "$(date '+%Y-%m-%d %H:%M:%S') - RCLOCAL update system time from RTC" >> ~/Desktop/rtc.log
 
 exit 0

--- a/OS_instructions/RTC/rc.local
+++ b/OS_instructions/RTC/rc.local
@@ -25,16 +25,19 @@ timedatectl set-ntp true
 sleep 1
 if timedatectl show -p NTPSynchronized | grep -q "yes"; then
   # Update RTC from system time
-  sudo hwclock --systohc --noadjfile --localtime
-  echo "$(date '+%Y-%m-%d %H:%M:%S') - RCLOCAL update RTC from system time" >> ~/Desktop/rtc.log
+  sudo hwclock --systohc --noadjfile --utc
+  
+  if [ "${RTC_LOGGING:-}" = "1" ]; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - RCLOCAL sync passed, updated RTC from system time" >> /home/pi/Desktop/rtc.log
+  fi
 else
-  echo "$(date '+%Y-%m-%d %H:%M:%S') - RCLOCAL not synced" >> ~/Desktop/rtc.log
+  # Update system time from RTC
+  timedatectl set-ntp false
+  sudo hwclock -s
+  
+  if [ "${RTC_LOGGING:-}" = "1" ]; then
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - RCLOCAL sync failed, updated system time from RTC and turned off sync" >> /home/pi/Desktop/rtc.log
+  fi
 fi
-
-# Always update system time from RTC!
-# For some reason this doesn't work in else statement
-timedatectl set-ntp false
-sudo hwclock -s
-echo "$(date '+%Y-%m-%d %H:%M:%S') - RCLOCAL update system time from RTC" >> ~/Desktop/rtc.log
 
 exit 0

--- a/OS_instructions/RTC/rc.local
+++ b/OS_instructions/RTC/rc.local
@@ -22,7 +22,7 @@ sudo bash -c 'echo ds1307 0x68 > /sys/class/i2c-adapter/i2c-1/new_device'
 
 # Check if system time is NPT synced
 timedatectl set-ntp true
-sleep(1)
+sleep 1
 if timedatectl show -p NTPSynchronized | grep -q "yes"; then
   # Update RTC from system time
   sudo hwclock --systohc --noadjfile --localtime


### PR DESCRIPTION
Update instructions to include details of 
* UTC vs local time RTC config in `timedatectl`
* Verification of clock in-use and `i2c-tools`

Update scripts such that
* Use UTC instead of local time when updating RTC from system time
* Fix incorrect `sleep` call
* Allow both ethernet and wifi conn in `dhcpcd.exit-hook`

Included logging for debugging, but removed in final version of the script. See commit `6c9711ace9a29254c2ebe94575a9ab53d599ef7e`