### PR TITLE
Option to specify default sample type

### DIFF
--- a/ulc_mm_package/QtGUI/gui_constants.py
+++ b/ulc_mm_package/QtGUI/gui_constants.py
@@ -67,10 +67,10 @@ SITE_LIST = [
 ]
 
 # Reorder the site list to move the environment variable specified default site to the first location
-env_var = os.getenv("DEFAULT_SITE")
+site_env_var = os.getenv("DEFAULT_SITE")
 
-if env_var in SITE_LIST:
-    SITE_LIST.insert(0, SITE_LIST.pop(SITE_LIST.index(env_var)))
+if site_env_var in SITE_LIST:
+    SITE_LIST.insert(0, SITE_LIST.pop(SITE_LIST.index(site_env_var)))
 
 
 CLINICAL_SAMPLE = "Whole blood (clinical, P. falciparum endemic)"
@@ -82,6 +82,11 @@ SAMPLE_LIST = [
     "Other/unknown",
     "Development (for testing use only)",
 ]
+
+# Reorder the sample type list
+sample_env_var = os.getenv("DEFAULT_SAMPLE_TYPE")
+if sample_env_var in SAMPLE_LIST:
+    SAMPLE_LIST.insert(0, SAMPLE_LIST.pop(SAMPLE_LIST.index(sample_env_var)))
 
 # ================ Experiment end conditions period ================ #
 # Timeout period


### PR DESCRIPTION
add the option to specify the default sample type as an environment variable, which will set which option the form defaults to in oracle