### PR TITLE
If default site set, disable site selection in form

### DIFF
--- a/ulc_mm_package/QtGUI/form_gui.py
+++ b/ulc_mm_package/QtGUI/form_gui.py
@@ -25,6 +25,7 @@ from ulc_mm_package.image_processing.processing_constants import TARGET_FLOWRATE
 from PyQt5.QtWidgets import QDateEdit, QTimeEdit
 from ulc_mm_package.QtGUI.gui_constants import (
     ICON_PATH,
+    SITE_ENV_VAR,
     SITE_LIST,
     SAMPLE_LIST,
     TOOLBAR_OFFSET,
@@ -129,6 +130,9 @@ class FormGUI(QDialog):
 
         self.site_val.addItems(SITE_LIST)
         self.sample_val.addItems(SAMPLE_LIST)
+
+        if SITE_ENV_VAR is not None:
+            self.site_val.setEnabled(False)
 
         # Set tab behavior
         self.notes_val.setTabChangesFocus(True)

--- a/ulc_mm_package/QtGUI/gui_constants.py
+++ b/ulc_mm_package/QtGUI/gui_constants.py
@@ -68,10 +68,10 @@ SITE_LIST = [
 ]
 
 # Reorder the site list to move the environment variable specified default site to the first location
-site_env_var = os.getenv("DEFAULT_SITE")
+SITE_ENV_VAR = os.getenv("DEFAULT_SITE")
 
-if site_env_var in SITE_LIST:
-    SITE_LIST.insert(0, SITE_LIST.pop(SITE_LIST.index(site_env_var)))
+if SITE_ENV_VAR in SITE_LIST:
+    SITE_LIST.insert(0, SITE_LIST.pop(SITE_LIST.index(SITE_ENV_VAR)))
 
 
 CLINICAL_SAMPLE = "Whole blood (clinical, P. falciparum endemic)"


### PR DESCRIPTION
If a `DEFAULT_SITE` has been set as an environment variable, disable location selection in the form in Oracle