### PR TITLE
Bump number of NCS model jobs

### DIFF
--- a/ulc_mm_package/neural_nets/NCSModel.py
+++ b/ulc_mm_package/neural_nets/NCSModel.py
@@ -87,7 +87,7 @@ class NCSModel:
         self._temp_infer_queue = AsyncInferQueue(self.model)
 
         # used for asyn
-        self.asyn_infer_queue = AsyncInferQueue(self.model)
+        self.asyn_infer_queue = AsyncInferQueue(self.model, jobs=16)
         self.asyn_infer_queue.set_callback(self._default_callback)
         self._asyn_results: List[
             Union[AsyncInferenceResult, List[AsyncInferenceResult]]

--- a/ulc_mm_package/neural_nets/NCSModel.py
+++ b/ulc_mm_package/neural_nets/NCSModel.py
@@ -87,7 +87,7 @@ class NCSModel:
         self._temp_infer_queue = AsyncInferQueue(self.model)
 
         # used for asyn
-        self.asyn_infer_queue = AsyncInferQueue(self.model, jobs=16)
+        self.asyn_infer_queue = AsyncInferQueue(self.model, jobs=8)
         self.asyn_infer_queue.set_callback(self._default_callback)
         self._asyn_results: List[
             Union[AsyncInferenceResult, List[AsyncInferenceResult]]


### PR DESCRIPTION
Increasing the number of jobs may help relieve queue buildup on the NCS. The default, when `jobs` is not specified in `AsyncInferQueue` is 4 on scope.