### PR TITLE
Study definition GUI optional key

### DIFF
--- a/ulc_mm_package/QtGUI/study_metadata_form.py
+++ b/ulc_mm_package/QtGUI/study_metadata_form.py
@@ -101,7 +101,6 @@ def create_widget_for_field(field_def):
         w.setSelectionMode(QAbstractItemView.MultiSelection)
     else:
         raise ValueError(f"Unsupported field type: {t}")
-
     return w
 
 
@@ -134,10 +133,11 @@ class StudyMetadata(QDialog):
 
             widget = create_widget_for_field(field)
             self._widgets[field["label"]] = (widget, field)
-            if field.get("required") is True:
+            if field.get("required") is True and field.get("show_gui") is not False:
                 self._required_widgets.append(widget)
                 self.btn_start.setEnabled(False)
-            layout.addRow(label, widget)
+            if field.get("show_gui") is not False:
+                layout.addRow(label, widget)
 
         self.btn_start.clicked.connect(self.validate)
         btn_cancel.clicked.connect(self.close)

--- a/ulc_mm_package/study_configurations/_example-config.toml
+++ b/ulc_mm_package/study_configurations/_example-config.toml
@@ -8,6 +8,7 @@ key = "key1"
 label = "numbers galore"
 datatype = "int"
 required = true
+show_gui = false # specify whether this field should show up in the form GUI in Oracle
 
 [[metadata]]
 key = "key2"


### PR DESCRIPTION
allow option for study definition fields to be marked as optional to be shown to the user (though will still be written to the csv)